### PR TITLE
Align ports to the three-mode registry

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -86,6 +86,12 @@
         },
         "serve": {
           "builder": "@angular/build:dev-server",
+          "options": {
+            "proxyConfig": "proxy.conf.json",
+            "port": 4201,
+            "host": "localhost",
+            "ssl": true
+          },
           "configurations": {
             "production": {
               "buildTarget": "client:build:production"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: andy_code_index_dev_password
       PGDATA: /var/lib/postgresql/data/pgdata
     ports:
-      - "5436:5432"
+      - "7436:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -40,9 +40,9 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
-      - "5101:8443"
-      - "5102:8080"
-      - "4201:8443"
+      - "7101:8443"
+      - "7102:8080"
+      - "6201:8443"
     volumes:
       - ./certs:/usr/local/share/ca-certificates/custom:ro
       - code_index_data:/data

--- a/src/Andy.CodeIndex.Api/Properties/launchSettings.json
+++ b/src/Andy.CodeIndex.Api/Properties/launchSettings.json
@@ -1,0 +1,22 @@
+{
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:5101;http://localhost:5102",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5102",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Andy.CodeIndex.Api/appsettings.Development.json
+++ b/src/Andy.CodeIndex.Api/appsettings.Development.json
@@ -6,12 +6,13 @@
       "Microsoft.EntityFrameworkCore": "Information"
     }
   },
+  "//": "Dev-override for `dotnet run + docker compose up deps` — points at Mode 2 docker host ports (Mode 1 + 2000). See andy-service-template/docs/ports.md.",
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5436;Database=andy_code_index;Username=andy_code_index;Password=andy_code_index_dev_password"
+    "DefaultConnection": "Host=localhost;Port=7436;Database=andy_code_index;Username=andy_code_index;Password=andy_code_index_dev_password"
   },
   "AndyAuth": {
     "Provider": "AndyAuth",
-    "Authority": "https://localhost:5001",
+    "Authority": "https://localhost:7001",
     "Audience": "urn:andy-code-index-api",
     "RequireHttpsMetadata": false
   },


### PR DESCRIPTION
Per rivoli-ai/andy-service-template#2. Mode 1 5101/5102/5436/4201, Mode 2 7101/7102/7436/6201.

Changes:
- `Properties/launchSettings.json`: **new file** (was missing — dotnet run was picking arbitrary ports)
- `appsettings.Development.json`: pg 5436→7436, AndyAuth 5001→7001 (Mode 2 overrides)
- `docker-compose.yml`: pg 5436→7436, api 5101/5102→7101/7102, and the 4201 API binding → 6201
- `client/angular.json`: pinned port 4201 + ssl + localhost host (was defaulting to 4200)

Reviewer note: `docker compose down && docker compose up -d` after merge.

Related: rivoli-ai/andy-service-template#2, rivoli-ai/andy-tasks#9.