### PR TITLE
fix: persist Data Protection key ring to DB (conductor#1160)

### DIFF
--- a/src/Andy.CodeIndex.Api/Program.cs
+++ b/src/Andy.CodeIndex.Api/Program.cs
@@ -8,6 +8,7 @@ using Andy.CodeIndex.Infrastructure.Services;
 using Andy.Rbac.Client;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
@@ -136,7 +137,14 @@ builder.Services.AddScoped<IEnrichmentRepository, EnrichmentRepository>();
 builder.Services.AddScoped<IIndexingTaskRepository, IndexingTaskRepository>();
 
 // --- Services ---
-builder.Services.AddDataProtection();
+// Persist Data Protection keys to the DB so encrypted values
+// (Repository.PersonalAccessToken via EncryptionService) survive
+// process restarts. Without this, AddDataProtection() uses an
+// ephemeral key ring and every restart re-keys, leaving any
+// previously-encrypted value un-Unprotectable. See conductor#1160.
+builder.Services.AddDataProtection()
+    .SetApplicationName("andy-code-index")
+    .PersistKeysToDbContext<CodeIndexDbContext>();
 builder.Services.AddScoped<IEncryptionService, EncryptionService>();
 builder.Services.AddScoped<IApiKeyResolver, ApiKeyResolver>();
 builder.Services.AddScoped<IRepositoryService, RepositoryService>();

--- a/src/Andy.CodeIndex.Infrastructure/Andy.CodeIndex.Infrastructure.csproj
+++ b/src/Andy.CodeIndex.Infrastructure/Andy.CodeIndex.Infrastructure.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">

--- a/src/Andy.CodeIndex.Infrastructure/Data/CodeIndexDbContext.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Data/CodeIndexDbContext.cs
@@ -1,14 +1,24 @@
 using Andy.CodeIndex.Domain.Entities;
+using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Andy.CodeIndex.Infrastructure.Data;
 
-public class CodeIndexDbContext : DbContext
+public class CodeIndexDbContext : DbContext, IDataProtectionKeyContext
 {
     public CodeIndexDbContext(DbContextOptions<CodeIndexDbContext> options)
         : base(options)
     {
     }
+
+    // Persisted Data Protection key ring — see conductor#1160. Without
+    // this, AddDataProtection() generates ephemeral in-memory keys; every
+    // process restart re-keys, and previously-encrypted values
+    // (Repository.PersonalAccessToken protected by EncryptionService)
+    // fail Unprotect on the first read after restart. The
+    // DataProtectionKeys table is created by the AddDataProtectionKeys
+    // migration.
+    public DbSet<DataProtectionKey> DataProtectionKeys => Set<DataProtectionKey>();
 
     public DbSet<Repository> Repositories => Set<Repository>();
     public DbSet<Commit> Commits => Set<Commit>();

--- a/src/Andy.CodeIndex.Infrastructure/Data/Migrations/20260513034244_AddDataProtectionKeys.Designer.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Data/Migrations/20260513034244_AddDataProtectionKeys.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Andy.CodeIndex.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Andy.CodeIndex.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(CodeIndexDbContext))]
-    partial class CodeIndexDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260513034244_AddDataProtectionKeys")]
+    partial class AddDataProtectionKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.CodeIndex.Infrastructure/Data/Migrations/20260513034244_AddDataProtectionKeys.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Data/Migrations/20260513034244_AddDataProtectionKeys.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Andy.CodeIndex.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDataProtectionKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DataProtectionKeys",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    FriendlyName = table.Column<string>(type: "text", nullable: true),
+                    Xml = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataProtectionKeys", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Commits_RepositoryId_CommittedAt",
+                table: "Commits",
+                columns: new[] { "RepositoryId", "CommittedAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DataProtectionKeys");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Commits_RepositoryId_CommittedAt",
+                table: "Commits");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

\`AddDataProtection()\` with no persistence backend uses an ephemeral in-memory key ring. Every process restart re-keys, so any value previously encrypted via \`IDataProtector\` — in this service, the \`Repository.PersonalAccessToken\` field via \`EncryptionService\` — becomes unreadable on next startup. Latent today (the cold-start path doesn't touch a stored PAT), but identical in shape to the active failure in andy-settings (conductor#1160 → fixed in rivoli-ai/andy-settings#95).

## Changes

- **\`Andy.CodeIndex.Infrastructure.csproj\`** — add \`Microsoft.AspNetCore.DataProtection.EntityFrameworkCore\` package.
- **\`CodeIndexDbContext\`** — implement \`IDataProtectionKeyContext\`; expose \`DbSet<DataProtectionKey>\`.
- **\`Program.cs\`** — \`AddDataProtection().SetApplicationName(\"andy-code-index\").PersistKeysToDbContext<CodeIndexDbContext>()\`.
- **Migration \`AddDataProtectionKeys\`** — creates the keyring table.

Pattern mirrors \`andy-containers/Andy.Containers.Api/Program.cs:159-161\`.

## Test plan

- [ ] Build green.
- [ ] Existing test suite passes.
- [ ] First-run migration creates the table on a fresh DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)