### PR TITLE
feat: honor ASPNETCORE_ENVIRONMENT=Embedded alongside Development

### DIFF
--- a/src/Andy.CodeIndex.Api/HostEnvironmentExtensions.cs
+++ b/src/Andy.CodeIndex.Api/HostEnvironmentExtensions.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Hosting;
+
+namespace Andy.CodeIndex.Api;
+
+// Named accessors for the three deployment modes (Development / Docker
+// / Embedded). See andy-service-template/docs/ports.md. Duplicated per
+// service — keep EmbeddedEnvironmentName in lock-step with the Swift
+// constant ServiceEnvironment.embeddedEnvironmentName.
+public static class HostEnvironmentExtensions
+{
+    public const string EmbeddedEnvironmentName = "Embedded";
+    public const string DockerEnvironmentName = "Docker";
+
+    public static bool IsEmbedded(this IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        return environment.IsEnvironment(EmbeddedEnvironmentName);
+    }
+
+    public static bool IsDocker(this IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        return environment.IsEnvironment(DockerEnvironmentName);
+    }
+
+    public static bool IsLocalOrEmbedded(this IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        return !environment.IsProduction();
+    }
+}

--- a/src/Andy.CodeIndex.Api/Program.cs
+++ b/src/Andy.CodeIndex.Api/Program.cs
@@ -1,4 +1,6 @@
 using Andy.Auth.Extensions;
+using Andy.CodeIndex.Api;
+// HostEnvironmentExtensions.IsEmbedded / IsLocalOrEmbedded
 using Andy.CodeIndex.Application.Interfaces;
 using Andy.CodeIndex.Application.Options;
 using Andy.CodeIndex.Infrastructure.Data;
@@ -41,7 +43,11 @@ if (!string.IsNullOrEmpty(andyAuthAuthority))
         {
             options.Authority = andyAuthAuthority;
             options.Audience = audience;
-            options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
+            // HTTPS metadata off in every non-production mode. Conductor's
+            // embedded mode talks to andy-auth over HTTP via the unified
+            // proxy on port 9100 — without IsLocalOrEmbedded() the JWT
+            // bearer middleware would refuse the discovery document.
+            options.RequireHttpsMetadata = !builder.Environment.IsLocalOrEmbedded();
             if (builder.Environment.IsDevelopment())
             {
                 options.BackchannelHttpHandler = new HttpClientHandler
@@ -414,8 +420,12 @@ app.MapGet("/health", () => Results.Ok(new { status = "healthy", timestamp = Dat
 
 app.MapFallbackToFile("index.html");
 
-// --- Auto-migrate in development ---
-if (app.Environment.IsDevelopment() && !string.IsNullOrEmpty(connectionString))
+// --- Auto-migrate (every non-production mode) ---
+// Embedded needs schema-on-first-boot too — without IsLocalOrEmbedded
+// a fresh install would launch with an empty Postgres DB and every
+// index/search request 500s. The `IsNpgsql()` guard keeps the
+// migration logic out of integration tests (InMemory provider).
+if (app.Environment.IsLocalOrEmbedded() && !string.IsNullOrEmpty(connectionString))
 {
     using var scope = app.Services.CreateScope();
     var db = scope.ServiceProvider.GetRequiredService<CodeIndexDbContext>();

--- a/tests/Andy.CodeIndex.Tests.Unit/HostEnvironmentExtensionsTests.cs
+++ b/tests/Andy.CodeIndex.Tests.Unit/HostEnvironmentExtensionsTests.cs
@@ -1,0 +1,37 @@
+using Andy.CodeIndex.Api;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Andy.CodeIndex.Tests.Unit;
+
+public class HostEnvironmentExtensionsTests
+{
+    [Theory]
+    [InlineData("Embedded", true)]
+    [InlineData("Development", false)]
+    [InlineData("Docker", false)]
+    [InlineData("Production", false)]
+    public void IsEmbedded_ReturnsExpected(string envName, bool expected)
+        => Assert.Equal(expected, new FakeEnv(envName).IsEmbedded());
+
+    [Theory]
+    [InlineData("Development", true)]
+    [InlineData("Docker", true)]
+    [InlineData("Embedded", true)]
+    [InlineData("Production", false)]
+    public void IsLocalOrEmbedded_TrueForNonProduction(string envName, bool expected)
+        => Assert.Equal(expected, new FakeEnv(envName).IsLocalOrEmbedded());
+
+    [Fact]
+    public void EmbeddedEnvironmentName_MatchesConductorContract()
+        => Assert.Equal("Embedded", HostEnvironmentExtensions.EmbeddedEnvironmentName);
+
+    private sealed class FakeEnv : IHostEnvironment
+    {
+        public FakeEnv(string name) => EnvironmentName = name;
+        public string EnvironmentName { get; set; }
+        public string ApplicationName { get; set; } = "test";
+        public string ContentRootPath { get; set; } = "/";
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+}


### PR DESCRIPTION
## Summary

Adds the standard `HostEnvironmentExtensions` helper + matching unit tests, then migrates two load-bearing `IsDevelopment()` branches in `Program.cs`:

| Branch | Old | New |
|---|---|---|
| `options.RequireHttpsMetadata` | `!IsDevelopment()` | `!IsLocalOrEmbedded()` |
| Postgres auto-migrate guard | `IsDevelopment()` | `IsLocalOrEmbedded()` (inner `IsNpgsql()` keeps tests safe) |

Audited but kept on `IsDevelopment()`:
- JWT bearer / RBAC-client SSL bypass — Embedded uses HTTP
- `AllowAllDevPolicyProvider` RBAC bypass — Embedded uses real RBAC
- `app.UseSwagger()` / `app.UseSwaggerUI()` — dev-iteration cosmetics
- MCP auth debug middleware — debug-only

`UseHttpsRedirection` not present in this service.

Part of [conductor#1163](https://github.com/rivoli-ai/conductor/issues/1163).

## Test plan

- [x] `dotnet build src/Andy.CodeIndex.Api` → 0 errors
- [ ] 4 unit-test failures + 1 integration failure observed but are **pre-existing on `main`** (RepoDiscoveryService + ScanCommitHandler + SyncRepositoryHandler + ChatApi suggestions) — unrelated to this PR; tracked elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)