### PR TITLE
fix(logging): silence EF Core SQL command logs at Information level

### DIFF
--- a/src/Andy.CodeIndex.Api/appsettings.json
+++ b/src/Andy.CodeIndex.Api/appsettings.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
     }
   },
   "AllowedHosts": "*",


### PR DESCRIPTION
## Summary

`appsettings.json` set `Default: Information` with no override for the `Microsoft.EntityFrameworkCore.*` logger categories. EF Core's default at Information logs every executed SQL command — the `IndexingTaskPoller`'s "any pending tasks?" tick runs a `SELECT ... FROM IndexingTasks WHERE Status='Pending' ORDER BY Priority DESC, CreatedAt LIMIT 1` on a 200ms cadence, so each poll dumped the full prepared-command text + parameters into stdout. Under Conductor's bundled-services orchestrator that tees to disk → ~172 MB / minute.

Add `Microsoft.EntityFrameworkCore.Database.Command: Warning` to the base `appsettings.json`. The Development override still sets `Microsoft.EntityFrameworkCore: Information` for local debugging (override wins). Embedded / Production / UAT inherit the new Warning gate.

## Verification

- Before: `andy-code-index.log` reached 177 MB in 60s, dominated by `info: Microsoft.EntityFrameworkCore.Database.Command[20101]` entries.
- After: log stable at ~6 KB over 60s. Remaining entries are real service events.

## Test plan

- [x] Live verification under Conductor's embedded launcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)