### PR TITLE
[help] Add docs/help/overview.md (HC.1.3 of rivoli-ai/conductor#1245)

### DIFF
--- a/docs/help/overview.md
+++ b/docs/help/overview.md
@@ -1,0 +1,38 @@
+---
+title: Andy Code Index Overview
+slug: andy-code-index-overview
+order: 1
+tags: [code, search, embeddings]
+---
+
+# Andy Code Index Overview
+
+Andy Code Index is the semantic code search service for the Andy ecosystem. It discovers repositories, walks file trees, computes embeddings, and serves hybrid (semantic + keyword) search with file-level citations.
+
+## What it does
+
+- Indexes every file in every registered repository — language-agnostic, parsed by tree-sitter where available.
+- Stores embeddings in PostgreSQL via pgvector; runs hybrid search by fusing pgvector cosine similarity with PostgreSQL `tsvector` keyword hits.
+- Returns citations (`path:line-range`) so the calling UI can deep-link the result into the editor.
+- Re-indexes incrementally on `git pull`; full re-index is rare.
+- Powers the chat panel's RAG when the conversation is grounded in repo content.
+
+## Key concepts
+
+- **Citation** — a `(repo, path, startLine, endLine)` tuple. Every search hit carries one; the UI uses it for previews and click-through.
+- **Hybrid score** — Reciprocal Rank Fusion over the embedding rank and the keyword rank, the same pattern Conductor's help search uses.
+- **Indexable file** — text files under a configurable size cap; binaries and generated files are skipped.
+
+## Where it fits
+
+The Conductor Code tab is a thin client over Code Index. The chat panel pulls citations from here when a prompt references repo state. Depends on bundled PostgreSQL (with pgvector) and on Auth for token validation.
+
+## Configuration
+
+Repository list and indexing thresholds live under `andy.code-index.*` in `andy-settings`. The pgvector connection string is baked into the embedded PostgreSQL bundle Conductor ships.
+
+## Troubleshooting
+
+- **Search returns nothing for a known file** — index is stale. Trigger a re-index from the Code tab or wait for the next poll cycle.
+- **"pgvector extension not found"** — embedded PostgreSQL didn't load the extension. Check `~/Library/Logs/Conductor/services/postgres.log` for `CREATE EXTENSION vector` errors.
+- **Indexing is slow** — large repos chew through embedding time. Add a `.codeindexignore` (gitignore-style) to skip vendored directories.


### PR DESCRIPTION
## Summary
Adds `docs/help/overview.md` — narrative help for andy-code-index that the Conductor in-app Help Center will ingest at runtime once rivoli-ai/conductor#1322 (the Conductor-side pipeline) ships.

## Why
The Conductor Help Center has manifest-derived per-service pages today (from `registration.json`), but no human-written context. HC.1.3 of the Conductor's HC epic (#1245) introduces `docs/help/` per repo as the canonical location for that narrative content. `scripts/build-all-services.sh` in conductor copies this folder into the bundled service tarball; `ServiceNarrativeHelpProvider` walks the bundle and serves the markdown in the Help window.

## Format
YAML front-matter (`title`, `slug`, `order`, `tags`) + markdown body, matching the contract `Conductor/Core/Help/NarrativeHelpIngest.swift` documents. Same pattern as conductor's own `welcome.md` + `getting-started.md`.

## Test plan
- [x] Markdown lints cleanly (no broken front-matter, no malformed YAML)
- [ ] After rivoli-ai/conductor#1322 merges + a Conductor rebuild via `scripts/build-all-services.sh`, the overview appears in Conductor's Help window under "andy-code-index"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
