### PR TITLE
feat(api): expose /openapi.json in all environments (HC.8.1 of rivoli-ai/conductor#1245)

### DIFF
--- a/src/Andy.CodeIndex.Api/Program.cs
+++ b/src/Andy.CodeIndex.Api/Program.cs
@@ -317,11 +317,19 @@ builder.Services.AddCors(options =>
 var app = builder.Build();
 
 // --- Middleware ---
+// HC.8.1 of rivoli-ai/conductor#1245: expose the OpenAPI
+// document in every environment so Conductor's in-app Help Center
+// can ingest /openapi.json from the bundled service. The Swagger
+// UI itself stays development-only.
+app.UseSwagger();
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
     app.UseSwaggerUI();
 }
+// Stable alias so every andy-* service exposes the same
+// path. HC.8.1 of rivoli-ai/conductor#1245.
+app.MapGet("/openapi.json", () => Results.Redirect("/swagger/v1/swagger.json"))
+    .ExcludeFromDescription();
 
 app.UseDefaultFiles();
 app.UseStaticFiles();


### PR DESCRIPTION
## Summary
Lifts Swashbuckle's `app.UseSwagger()` out of the dev-only block + adds a stable `/openapi.json` alias that 301-redirects to `/swagger/v1/swagger.json`. Swagger UI stays development-only.

## Why
HC.8.1 of rivoli-ai/conductor#1245. The Conductor in-app Help Center wants to ingest every bundled service's OpenAPI document at a known path. Today the spec only exists in the Development environment — Conductor runs services with Production defaults, so the path returns 404. Lifting `UseSwagger()` out of the guard makes the document available everywhere (it's generated on demand; no cost when nobody calls it). The `/openapi.json` alias gives every service a uniform path so a single Conductor-side renderer (HC.8.2) handles all of them.

## What changes
```diff
- if (app.Environment.IsDevelopment())
- {
-     app.UseSwagger();
-     app.UseSwaggerUI();
- }
+ app.UseSwagger();
+ if (app.Environment.IsDevelopment())
+ {
+     app.UseSwaggerUI();
+ }
+ app.MapGet("/openapi.json", () => Results.Redirect("/swagger/v1/swagger.json"))
+     .ExcludeFromDescription();
```

## Test plan
- [x] `dotnet build` succeeds in this PR's worktree
- [ ] After merge: `curl http://localhost:<port>/openapi.json` against the bundled service in Conductor returns the spec (verified by HC.8.2 work in conductor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
