### PR TITLE
[help] French translation of docs/help/overview.md (HC.4.4 of rivoli-ai/conductor#1245)

### DIFF
--- a/docs/help/overview.fr.md
+++ b/docs/help/overview.fr.md
@@ -1,0 +1,38 @@
+---
+title: Présentation d'Andy Code Index
+slug: andy-code-index-overview
+order: 1
+tags: [code, search, embeddings]
+---
+
+# Présentation d'Andy Code Index
+
+Andy Code Index est le service de recherche sémantique de code de l'écosystème Andy. Il découvre les dépôts, parcourt les arborescences de fichiers, calcule les plongements et sert une recherche hybride (sémantique + mots-clés) avec citations au niveau du fichier.
+
+## Ce qu'il fait
+
+- Indexe chaque fichier de chaque dépôt enregistré — agnostique au langage, parsé par tree-sitter quand disponible.
+- Stocke les plongements dans PostgreSQL via pgvector ; exécute la recherche hybride en fusionnant la similarité cosinus pgvector avec les hits par mots-clés `tsvector` PostgreSQL.
+- Retourne des citations (`chemin:plage-de-lignes`) pour que l'UI appelante puisse créer un lien profond vers l'éditeur.
+- Réindexe de façon incrémentale lors d'un `git pull` ; la réindexation complète est rare.
+- Alimente le RAG du panneau de chat lorsque la conversation est ancrée dans le contenu du dépôt.
+
+## Concepts clés
+
+- **Citation** — un tuple `(repo, chemin, ligneDébut, ligneFin)`. Chaque hit de recherche en porte une ; l'UI l'utilise pour les aperçus et la navigation par clic.
+- **Score hybride** — Reciprocal Rank Fusion sur le rang du plongement et le rang des mots-clés, le même schéma qu'utilise la recherche d'aide de Conductor.
+- **Fichier indexable** — fichiers texte sous un plafond de taille configurable ; les binaires et fichiers générés sont ignorés.
+
+## Où il s'intègre
+
+L'onglet Code de Conductor est un client mince au-dessus de Code Index. Le panneau de chat tire des citations d'ici quand un prompt référence l'état du dépôt. Dépend du PostgreSQL embarqué (avec pgvector) et d'Auth pour la validation des jetons.
+
+## Configuration
+
+La liste des dépôts et les seuils d'indexation résident sous `andy.code-index.*` dans `andy-settings`. La chaîne de connexion pgvector est intégrée dans le bundle PostgreSQL embarqué que Conductor livre.
+
+## Dépannage
+
+- **La recherche ne retourne rien pour un fichier connu** — l'index est obsolète. Déclenchez une réindexation depuis l'onglet Code ou attendez le prochain cycle de sondage.
+- **« pgvector extension not found »** — le PostgreSQL embarqué n'a pas chargé l'extension. Vérifiez `~/Library/Logs/Conductor/services/postgres.log` pour les erreurs `CREATE EXTENSION vector`.
+- **L'indexation est lente** — les gros dépôts mangent du temps de plongement. Ajoutez un `.codeindexignore` (style gitignore) pour ignorer les répertoires vendorisés.


### PR DESCRIPTION
## Summary
Adds `docs/help/overview.fr.md` — the French translation of `overview.md` shipped under HC.1.3. Mirrors the existing English structure (What it does / Key concepts / Where it fits / Configuration / Troubleshooting).

## Why
HC.4.4 of the Conductor HC epic (rivoli-ai/conductor#1245) calls for a translation pipeline for narrative `.md` articles authored in each service repo. The Conductor side already supports it (HC.4.1 ingest convention + HC.4.2 multilingual embedder + HC.4.3 locale-aware UX). This PR is the per-service proof-of-concept — drop a `<basename>.<locale>.md` sibling, and `NarrativeHelpIngest.peelLocaleSuffix` automatically tags the article with `locale=fr` so `HelpCorpus.filtered(forLocale:)` serves it when the user's Help language is French.

## Format
Same YAML front-matter shape as the English `overview.md`, with `title:` and body in French. No `locale:` front-matter needed — the filename suffix is recognised automatically.

## Next locales
The pipeline is the same for every other locale Conductor supports: drop `overview.<code>.md` for any of `de`, `es`, `it`, `ja`, `ko`, `nl`, `pl`, `pt-BR`, `ru`, `tr`, `zh-Hans` and it lands in the Help corpus automatically once Conductor rebuilds.

## Test plan
- [x] Markdown lints (no broken front-matter, no malformed YAML)
- [ ] After Conductor rebuild via `scripts/build-all-services.sh`, the French overview appears in Conductor's Help window when **Settings → Help → Language** is set to Français (or system locale is fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
