### PR TITLE
fix(bundle): pin Logging.Abstractions 9.0 to satisfy AI.Abstractions ref (#237)

### DIFF
--- a/src/Andy.CodeIndex.Api/Andy.CodeIndex.Api.csproj
+++ b/src/Andy.CodeIndex.Api/Andy.CodeIndex.Api.csproj
@@ -26,6 +26,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <!-- #237 — ModelContextProtocol 0.4.0-preview.3 brings in
+         Microsoft.Extensions.AI.Abstractions 9.10.0, whose net8.0 DLL
+         has an AssemblyRef to Microsoft.Extensions.Logging.Abstractions
+         9.0.0.0. The ASP.NET Core 8 shared framework only ships the
+         8.x DLL, so Program.Main blows up with FileNotFoundException
+         before any host setup runs. Pin the 9.0 floor explicitly so
+         publish copies the matching DLL into the bundle. -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.3" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.3" />
     <!-- OT4 (rivoli-ai/conductor#1262) — service-specific EF Core tracing; not bundled in Andy.Telemetry. -->


### PR DESCRIPTION
## Summary
- ModelContextProtocol 0.4.0-preview.3 transitively brings in `Microsoft.Extensions.AI.Abstractions 9.10.0`, whose net8.0 DLL has an `AssemblyRef` to `Microsoft.Extensions.Logging.Abstractions 9.0.0.0`. The ASP.NET Core 8 shared framework only ships the 8.x DLL, so the host throws `FileNotFoundException` before `Program.Main` runs and the service crash-loops on Conductor launch.
- Pin `Microsoft.Extensions.Logging.Abstractions` to `9.0.0` explicitly so `dotnet publish` copies the matching DLL into the self-contained bundle.

## Test plan
- [x] `dotnet publish` → bundle now contains `Microsoft.Extensions.Logging.Abstractions.dll` from the 9.0.0 package and `deps.json` references `Microsoft.Extensions.Logging.Abstractions/9.0.0`.
- [x] Run the published binary locally → no more `FileNotFoundException` for Logging.Abstractions 9.0.0.0; the host reaches startup (remaining DI errors are unrelated standalone-config noise when not run under Conductor).
- [x] Unit tests: 747/751 pass, same 4 pre-existing failures as `main` — unaffected by this change.
- [ ] Re-bundle in Conductor and confirm `~/Library/Logs/Conductor/services/andy-code-index.log` no longer shows the FileNotFoundException loop.

Fixes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)