### PR TITLE
[SM.2.9] Add missing EF migration for IndexingTask.LastHeartbeatAt + Seq

### DIFF
--- a/src/Andy.CodeIndex.Infrastructure/Data/Migrations/20260606185342_SM29_AddHeartbeatAndSeq.Designer.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Data/Migrations/20260606185342_SM29_AddHeartbeatAndSeq.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Andy.CodeIndex.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Andy.CodeIndex.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(CodeIndexDbContext))]
-    partial class CodeIndexDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260606185342_SM29_AddHeartbeatAndSeq")]
+    partial class SM29_AddHeartbeatAndSeq
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.CodeIndex.Infrastructure/Data/Migrations/20260606185342_SM29_AddHeartbeatAndSeq.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Data/Migrations/20260606185342_SM29_AddHeartbeatAndSeq.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.CodeIndex.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SM29_AddHeartbeatAndSeq : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastHeartbeatAt",
+                table: "IndexingTasks",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "Seq",
+                table: "IndexingTasks",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IndexingTasks_Status_LastHeartbeatAt",
+                table: "IndexingTasks",
+                columns: new[] { "Status", "LastHeartbeatAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Commits_RepositoryId_CommittedAt",
+                table: "Commits",
+                columns: new[] { "RepositoryId", "CommittedAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_IndexingTasks_Status_LastHeartbeatAt",
+                table: "IndexingTasks");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Commits_RepositoryId_CommittedAt",
+                table: "Commits");
+
+            migrationBuilder.DropColumn(
+                name: "LastHeartbeatAt",
+                table: "IndexingTasks");
+
+            migrationBuilder.DropColumn(
+                name: "Seq",
+                table: "IndexingTasks");
+        }
+    }
+}


### PR DESCRIPTION
SM.2.9 added `LastHeartbeatAt` + `Seq` to the `IndexingTask` entity + `OnModelCreating` + the model snapshot, but shipped **no EF migration**. `Program.cs` runs `Database.MigrateAsync()`, so on every install (fresh or existing) the columns are never created and the WatchdogService/BackgroundWorker fail every cycle with `42703: column i.LastHeartbeatAt does not exist`.

This adds the missing migration (both columns + the `{Status, LastHeartbeatAt}` watchdog index + a missing `Commits` index that had also drifted).

Verified locally: `MigrateAsync` applies it on startup ("Applying migration … SM29_AddHeartbeatAndSeq"); 0 errors after; WatchdogService/BackgroundWorker run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)