### PR TITLE
Hybrid search & retrieval correctness (epic #244)

### DIFF
--- a/src/Andy.CodeIndex.Infrastructure/Services/EmbeddingService.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Services/EmbeddingService.cs
@@ -94,8 +94,14 @@ public class EmbeddingService : IEmbeddingService
         var currentBatch = new List<string>();
         var currentChars = 0;
 
-        foreach (var text in texts)
+        foreach (var rawText in texts)
         {
+            // Bound a single oversized text. Previously a text longer than
+            // MaxBatchChars was placed in a batch alone and sent un-truncated,
+            // which exceeds the provider's token limit and fails the whole
+            // request (story #253). Truncate to the per-request char budget.
+            var text = TruncateToCharBudget(rawText);
+
             if (currentBatch.Count >= _options.MaxBatchSize ||
                 (currentChars + text.Length > _options.MaxBatchChars && currentBatch.Count > 0))
             {
@@ -112,5 +118,27 @@ public class EmbeddingService : IEmbeddingService
             batches.Add(currentBatch.ToArray());
 
         return batches;
+    }
+
+    /// <summary>
+    /// Truncates a single text to the per-request character budget so it cannot
+    /// exceed the embedding provider's token limit. Backs off one char if the cut
+    /// would split a UTF-16 surrogate pair.
+    /// </summary>
+    internal string TruncateToCharBudget(string text)
+    {
+        var max = _options.MaxBatchChars;
+        if (max <= 0 || text.Length <= max)
+            return text;
+
+        var cut = max;
+        if (char.IsHighSurrogate(text[cut - 1]))
+            cut--;
+
+        _logger.LogWarning(
+            "Embedding input of {Length} chars exceeds MaxBatchChars {Max}; truncating before send",
+            text.Length, max);
+
+        return text[..cut];
     }
 }

--- a/src/Andy.CodeIndex.Infrastructure/Services/SearchService.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Services/SearchService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text;
 using Andy.CodeIndex.Application.DTOs;
 using Andy.CodeIndex.Application.Interfaces;
 using Andy.CodeIndex.Domain.Entities;
@@ -53,17 +54,48 @@ public class SearchService : ISearchService
 
         var vectorStr = "[" + string.Join(",", queryEmbedding[0]) + "]";
 
+        // Build a parameterized WHERE so the SearchFilter (language/repo/path)
+        // constrains the semantic arm too. Without this, a language/repo filter
+        // silently leaked cross-language/cross-repo results through the vector
+        // query while only the keyword arm was filtered (epic #244 / story #251,
+        // related security finding #226). {0} is the query vector; filter values
+        // and the limit are appended as positional parameters.
+        var parameters = new List<object> { vectorStr };
+        var where = new StringBuilder();
+
+        if (filter?.Languages is { Count: > 0 })
+        {
+            where.Append($@" AND e.""Language"" = ANY({{{parameters.Count}}})");
+            parameters.Add(filter.Languages.ToArray());
+        }
+        if (filter?.RepositoryIds is { Count: > 0 })
+        {
+            where.Append($@" AND e.""RepositoryId"" = ANY({{{parameters.Count}}})");
+            parameters.Add(filter.RepositoryIds.ToArray());
+        }
+        if (!string.IsNullOrEmpty(filter?.FilePath))
+        {
+            where.Append($@" AND e.""FilePath"" IS NOT NULL AND strpos(e.""FilePath"", {{{parameters.Count}}}) > 0");
+            parameters.Add(filter.FilePath);
+        }
+
+        var limitIndex = parameters.Count;
+        parameters.Add(limit);
+
         // Use raw SQL for pgvector cosine distance operator
-        var results = await _context.Database
-            .SqlQuery<SemanticSearchRow>($@"
+        var sql = $@"
                 SELECT ce.""EnrichmentId"", e.""Content"", e.""FilePath"", e.""StartLine"", e.""EndLine"",
                        e.""Language"", e.""RepositoryId"", r.""Name"" AS ""RepositoryName"",
-                       1.0 - (ce.""EmbeddingVector"" <=> {vectorStr}::vector) AS ""Score""
+                       1.0 - (ce.""EmbeddingVector"" <=> {{0}}::vector) AS ""Score""
                 FROM ""ContentEmbeddings"" ce
                 JOIN ""Enrichments"" e ON ce.""EnrichmentId"" = e.""Id""
                 JOIN ""Repositories"" r ON e.""RepositoryId"" = r.""Id""
-                ORDER BY ce.""EmbeddingVector"" <=> {vectorStr}::vector
-                LIMIT {limit}")
+                WHERE 1=1{where}
+                ORDER BY ce.""EmbeddingVector"" <=> {{0}}::vector
+                LIMIT {{{limitIndex}}}";
+
+        var results = await _context.Database
+            .SqlQueryRaw<SemanticSearchRow>(sql, parameters.ToArray())
             .ToListAsync(ct);
 
         return new SearchResultsDto
@@ -115,16 +147,23 @@ public class SearchService : ISearchService
         List<SearchResultItem> results;
         if (_context.Database.IsNpgsql())
         {
-            var tsQuery = string.Join(" & ", keywords.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+            // Use websearch_to_tsquery instead of to_tsquery: it never throws on
+            // user input containing tsquery syntax characters (':', '(', '!', '&')
+            // and tokenizes the raw phrase itself, so we no longer hand-join terms
+            // with '&' (story #252). Config stays 'english' to match the stored
+            // tsvector computed column (CodeIndexDbContext: to_tsvector('english',...));
+            // moving to the 'simple' config for code identifiers requires
+            // regenerating that column via migration (tracked separately).
+            var tsQuery = keywords;
             results = await enrichmentQuery
-                .Where(e => e.SearchVector!.Matches(EF.Functions.ToTsQuery("english", tsQuery)))
-                .OrderByDescending(e => e.SearchVector!.Rank(EF.Functions.ToTsQuery("english", tsQuery)))
+                .Where(e => e.SearchVector!.Matches(EF.Functions.WebSearchToTsQuery("english", tsQuery)))
+                .OrderByDescending(e => e.SearchVector!.Rank(EF.Functions.WebSearchToTsQuery("english", tsQuery)))
                 .Take(limit)
                 .Select(e => new SearchResultItem
                 {
                     EnrichmentId = e.Id,
                     Content = e.Content,
-                    Score = e.SearchVector!.Rank(EF.Functions.ToTsQuery("english", tsQuery)),
+                    Score = e.SearchVector!.Rank(EF.Functions.WebSearchToTsQuery("english", tsQuery)),
                     FilePath = e.FilePath,
                     StartLine = e.StartLine,
                     EndLine = e.EndLine,
@@ -191,14 +230,15 @@ public class SearchService : ISearchService
 
         var sw = Stopwatch.StartNew();
 
-        // Run semantic and keyword searches concurrently
-        var semanticTask = SemanticSearchAsync(query, filter, limit * 2, ct);
-        var keywordTask = KeywordSearchAsync(query, filter, limit * 2, ct);
-
-        await Task.WhenAll(semanticTask, keywordTask);
-
-        var semanticResults = semanticTask.Result;
-        var keywordResults = keywordTask.Result;
+        // Run the arms sequentially: both share the request-scoped DbContext,
+        // which is not thread-safe. Running them via Task.WhenAll triggers EF
+        // Core's "a second operation was started on this context" error whenever
+        // the two queries overlap — previously masked in production only by the
+        // embedding network call delaying the semantic query past the keyword
+        // query (epic #244). The DB queries are fast; the dominant cost is the
+        // one-time embedding generation, so the latency impact is negligible.
+        var semanticResults = await SemanticSearchAsync(query, filter, limit * 2, ct);
+        var keywordResults = await KeywordSearchAsync(query, filter, limit * 2, ct);
 
         // Convert to ranked result sets for RRF
         var inputs = new List<RankedResultSet>();
@@ -279,20 +319,6 @@ public class SearchService : ISearchService
             new KeyValuePair<string, object?>("andy.code_index.query.mode", "hybrid"),
             new KeyValuePair<string, object?>("mode", "hybrid")); // deprecated; removed in 0.3.0
         return result;
-    }
-
-    private static IQueryable<ContentEmbedding> ApplyEmbeddingFilters(IQueryable<ContentEmbedding> query, SearchFilter? filter)
-    {
-        if (filter is null) return query;
-
-        if (filter.Languages is { Count: > 0 })
-            query = query.Where(e => filter.Languages.Contains(e.Enrichment.Language!));
-        if (filter.RepositoryIds is { Count: > 0 })
-            query = query.Where(e => filter.RepositoryIds.Contains(e.Enrichment.RepositoryId));
-        if (filter.FilePath is not null)
-            query = query.Where(e => e.Enrichment.FilePath != null && e.Enrichment.FilePath.Contains(filter.FilePath));
-
-        return query;
     }
 
     private static IQueryable<Enrichment> ApplyEnrichmentFilters(IQueryable<Enrichment> query, SearchFilter? filter)

--- a/tests/Andy.CodeIndex.Tests.Integration/Andy.CodeIndex.Tests.Integration.csproj
+++ b/tests/Andy.CodeIndex.Tests.Integration/Andy.CodeIndex.Tests.Integration.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Andy.CodeIndex.Tests.Integration/HybridSearchPgvectorTests.cs
+++ b/tests/Andy.CodeIndex.Tests.Integration/HybridSearchPgvectorTests.cs
@@ -1,0 +1,216 @@
+using Andy.CodeIndex.Application.Interfaces;
+using Andy.CodeIndex.Domain.Entities;
+using Andy.CodeIndex.Domain.Enums;
+using Andy.CodeIndex.Infrastructure.Data;
+using Andy.CodeIndex.Infrastructure.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Pgvector;
+using Pgvector.EntityFrameworkCore;
+using Testcontainers.PostgreSql;
+
+namespace Andy.CodeIndex.Tests.Integration;
+
+/// <summary>
+/// End-to-end search correctness against a real PostgreSQL + pgvector instance
+/// (epic #244). EF InMemory cannot run the pgvector cosine operator or the
+/// tsvector full-text path, so the previous suite never executed the semantic
+/// arm, RRF fusion, or filter application — ordering was asserted nowhere.
+/// These tests seed deterministic vectors into pgvector/pgvector:pg16 and assert:
+/// (1) semantic ranking order, (2) the language filter now constrains the
+/// semantic arm (story #251), (3) the hardened FTS query does not throw on
+/// tsquery syntax characters (story #252), and (4) hybrid fusion produces a
+/// descending-scored, non-empty result set.
+///
+/// The container is shared across all tests via a collection fixture (one
+/// container, seeded once, read-only tests). The collection sets
+/// DisableParallelization so this Docker-backed suite runs in isolation rather
+/// than racing the ~98 in-memory WebApplicationFactory tests for resources.
+/// Requires Docker.
+/// </summary>
+[Collection("Pgvector")]
+public sealed class HybridSearchPgvectorTests
+{
+    private readonly PgvectorFixture _fx;
+
+    public HybridSearchPgvectorTests(PgvectorFixture fx) => _fx = fx;
+
+    [Fact]
+    public async Task SemanticSearch_OrdersByCosineSimilarityDescending()
+    {
+        var result = await _fx.Search.SemanticSearchAsync("anything", filter: null, limit: 10);
+
+        result.Results.Should().HaveCount(4);
+        result.Results[0].EnrichmentId.Should().Be(PgvectorFixture.IdA, "A == e0 is identical to the query vector");
+        result.Results.Select(r => r.Score).Should().BeInDescendingOrder();
+    }
+
+    [Fact]
+    public async Task SemanticSearch_LanguageFilter_ConstrainsTheSemanticArm()
+    {
+        // Story #251 regression: before wiring the filter into the raw SQL, the
+        // semantic arm ignored it and leaked csharp/javascript results.
+        var filter = new SearchFilter { Languages = ["python"] };
+
+        var result = await _fx.Search.SemanticSearchAsync("anything", filter, limit: 10);
+
+        result.Results.Should().OnlyContain(r => r.Language == "python");
+        result.Results.Select(r => r.EnrichmentId).Should().Equal(PgvectorFixture.IdA, PgvectorFixture.IdC);
+    }
+
+    [Fact]
+    public async Task KeywordSearch_DoesNotThrowOnTsQuerySyntaxCharacters()
+    {
+        // Story #252: to_tsquery threw on ':', '(', '!', '&'. websearch_to_tsquery
+        // tolerates them.
+        var act = async () => await _fx.Search.KeywordSearchAsync("service: (python)! & <>", filter: null, limit: 10);
+
+        var result = await act.Should().NotThrowAsync();
+        result.Subject.Results.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task HybridSearch_FusesBothArms_OrderedDescending()
+    {
+        var result = await _fx.Search.HybridSearchAsync("service", filter: null, limit: 10);
+
+        result.SearchMode.Should().Be("hybrid");
+        result.Results.Should().NotBeEmpty();
+        result.Results.Select(r => r.Score).Should().BeInDescendingOrder();
+    }
+
+    [Fact]
+    public async Task HybridSearch_RepositoryFilter_AppliesToBothArms()
+    {
+        var filter = new SearchFilter { RepositoryIds = [Guid.Parse("99999999-9999-9999-9999-999999999999")] };
+
+        var result = await _fx.Search.HybridSearchAsync("service", filter, limit: 10);
+
+        result.Results.Should().BeEmpty("no enrichment belongs to the filtered repository");
+    }
+}
+
+/// <summary>
+/// Binds <see cref="PgvectorFixture"/> to the "Pgvector" collection and disables
+/// parallelization so the Docker-backed tests do not contend with the rest of
+/// the assembly.
+/// </summary>
+[CollectionDefinition("Pgvector", DisableParallelization = true)]
+public sealed class PgvectorCollection : ICollectionFixture<PgvectorFixture>;
+
+/// <summary>
+/// Shared pgvector container + seeded data for <see cref="HybridSearchPgvectorTests"/>.
+/// Vectors are unit-norm so cosine similarity (= Score, since the query embedding
+/// is e0) is the leading component of each: A=1.0, B=0.8, C=0.6, D=0.0.
+/// </summary>
+public sealed class PgvectorFixture : IAsyncLifetime
+{
+    private const int Dim = 1536;
+
+    public static readonly Guid RepoId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    public static readonly Guid IdA = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001");
+    public static readonly Guid IdB = Guid.Parse("bbbbbbbb-0000-0000-0000-000000000002");
+    public static readonly Guid IdC = Guid.Parse("cccccccc-0000-0000-0000-000000000003");
+    public static readonly Guid IdD = Guid.Parse("dddddddd-0000-0000-0000-000000000004");
+
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("pgvector/pgvector:pg16").Build();
+    private CodeIndexDbContext _context = null!;
+
+    public SearchService Search { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        var options = new DbContextOptionsBuilder<CodeIndexDbContext>()
+            .UseNpgsql(_container.GetConnectionString(), o => o.UseVector())
+            .Options;
+
+        _context = new CodeIndexDbContext(options);
+        await _context.Database.MigrateAsync();
+        await SeedAsync();
+
+        var provider = new StubEmbeddingProvider(Unit(0));
+        Search = new SearchService(_context, provider, new RankFusionService(), NullLogger<SearchService>.Instance);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_context is not null)
+            await _context.DisposeAsync();
+        await _container.DisposeAsync();
+    }
+
+    private async Task SeedAsync()
+    {
+        _context.Repositories.Add(new Repository
+        {
+            Id = RepoId,
+            Name = "seed-repo",
+            Url = "https://example.test/seed",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+
+        // (id, language, vector, content). All contents share "service" so the
+        // keyword arm returns every row.
+        var seeds = new[]
+        {
+            (IdA, "python", Unit(0), "alpha service python module"),
+            (IdB, "csharp", Blend(0, 0.8f, 1, 0.6f), "beta service csharp module"),
+            (IdC, "python", Blend(0, 0.6f, 1, 0.8f), "gamma service python module"),
+            (IdD, "javascript", Unit(1), "delta service javascript module"),
+        };
+
+        foreach (var (id, lang, vec, content) in seeds)
+        {
+            _context.Enrichments.Add(new Enrichment
+            {
+                Id = id,
+                RepositoryId = RepoId,
+                Type = EnrichmentType.Development,
+                Subtype = EnrichmentSubtype.Snippet,
+                Content = content,
+                FilePath = $"src/{lang}/file.txt",
+                Language = lang,
+                CreatedAt = DateTime.UtcNow,
+            });
+            _context.ContentEmbeddings.Add(new ContentEmbedding
+            {
+                Id = Guid.NewGuid(),
+                EnrichmentId = id,
+                EmbeddingVector = new Vector(vec),
+                IndexType = IndexType.Code,
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+
+        await _context.SaveChangesAsync();
+    }
+
+    private static float[] Unit(int index)
+    {
+        var v = new float[Dim];
+        v[index] = 1f;
+        return v;
+    }
+
+    private static float[] Blend(int i0, float w0, int i1, float w1)
+    {
+        var v = new float[Dim];
+        v[i0] = w0;
+        v[i1] = w1;
+        return v;
+    }
+
+    private sealed class StubEmbeddingProvider(float[] queryVector) : IEmbeddingProvider
+    {
+        public int Dimensions => Dim;
+        public string ModelName => "stub";
+        public bool IsAvailable => true;
+
+        public Task<float[][]> GenerateEmbeddingsAsync(string[] texts, CancellationToken ct = default)
+            => Task.FromResult(texts.Select(_ => queryVector).ToArray());
+    }
+}


### PR DESCRIPTION
Implements **epic #244 — Hybrid search & retrieval correctness**, end to end.

## What & why
Fixes a cluster of validity bugs on the primary search path and adds the suite's first ranking/ordering assertions, verified against a real PostgreSQL + pgvector instance (Testcontainers).

| Story | Fix |
|-------|-----|
| #251 | Wire language/repo/path filters into the **semantic** pgvector SQL (parameterized `SqlQueryRaw`). The filter was ignored on the semantic arm, leaking cross-language/cross-repo results in hybrid mode. Removes the dead `ApplyEmbeddingFilters`. (Related: security #226.) |
| #252 | `to_tsquery` → `websearch_to_tsquery` — queries with tsquery syntax chars (`:` `(` `!` `&`) no longer throw. Config kept `english` to match the stored tsvector column (moving to `simple` for code identifiers needs a column-regeneration migration, tracked separately). |
| #253 | Truncate any single embedding input over `MaxBatchChars` (surrogate-safe) so one oversized chunk can't exceed the provider token limit. |
| #264 | **Bug found by the #254 test:** `HybridSearchAsync` ran both arms via `Task.WhenAll` on the shared, non-thread-safe scoped `DbContext` → EF concurrency exception when queries overlap (a latent intermittent 500 masked in prod by embedding latency). Now sequential. |
| #254 | New `HybridSearchPgvectorTests` — pgvector container, deterministic vectors; asserts semantic ranking order, semantic-arm filter exclusivity, FTS syntax tolerance, hybrid fusion order. Runs in an isolated, non-parallel collection fixture. |

## Testing
- Full solution builds clean (0 warnings).
- Unit search/embedding: 29/29.
- Integration: 102 passed. The one remaining failure — `ChatApiTests.GetSuggestions_Returns10Dimensions` (10-vs-11 dimensions) — **pre-exists on `main`** and is unrelated to this change.

Closes #251, #252, #253, #254, #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)