### PR TITLE
Roslyn-based C# API extraction (story #247)

### DIFF
--- a/src/Andy.CodeIndex.Application/Interfaces/ICodeAnalysisService.cs
+++ b/src/Andy.CodeIndex.Application/Interfaces/ICodeAnalysisService.cs
@@ -24,6 +24,7 @@ public class ApiClass
     public List<string> ImplementedInterfaces { get; set; } = [];
     public List<ApiMethod> Methods { get; set; } = [];
     public List<ApiProperty> Properties { get; set; } = [];
+    public string? Summary { get; set; }
 }
 
 public class ApiInterface
@@ -31,6 +32,7 @@ public class ApiInterface
     public required string Name { get; set; }
     public List<ApiMethod> Methods { get; set; } = [];
     public List<ApiProperty> Properties { get; set; } = [];
+    public string? Summary { get; set; }
 }
 
 public class ApiMethod
@@ -41,6 +43,7 @@ public class ApiMethod
     public string? AccessModifier { get; set; }
     public bool IsStatic { get; set; }
     public bool IsAsync { get; set; }
+    public string? Summary { get; set; }
 }
 
 public class ApiProperty
@@ -50,6 +53,7 @@ public class ApiProperty
     public string? AccessModifier { get; set; }
     public bool HasGetter { get; set; }
     public bool HasSetter { get; set; }
+    public string? Summary { get; set; }
 }
 
 public class ApiParameter
@@ -65,10 +69,12 @@ public class ApiFunction
     public required string ReturnType { get; set; }
     public List<ApiParameter> Parameters { get; set; } = [];
     public bool IsExported { get; set; }
+    public string? Summary { get; set; }
 }
 
 public class ApiEnum
 {
     public required string Name { get; set; }
     public List<string> Values { get; set; } = [];
+    public string? Summary { get; set; }
 }

--- a/src/Andy.CodeIndex.Infrastructure/Andy.CodeIndex.Infrastructure.csproj
+++ b/src/Andy.CodeIndex.Infrastructure/Andy.CodeIndex.Infrastructure.csproj
@@ -11,6 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.11" />
+    <!-- Pinned to 4.5.0 to match the version EF Core Design 8.0.11 transitively
+         requires (Microsoft.CodeAnalysis.CSharp.Workspaces 4.5.0 → Common 4.5.0). -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">

--- a/src/Andy.CodeIndex.Infrastructure/Services/CodeAnalysisService.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Services/CodeAnalysisService.cs
@@ -1,6 +1,9 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using Andy.CodeIndex.Application.Interfaces;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Andy.CodeIndex.Infrastructure.Services;
 
@@ -51,6 +54,8 @@ public class CodeAnalysisService : ICodeAnalysisService
         foreach (var cls in result.Classes)
         {
             sb.AppendLine($"## Class: `{cls.Name}`");
+            if (cls.Summary is not null)
+                sb.AppendLine($"_{cls.Summary}_  ");
             if (cls.BaseClass is not null)
                 sb.AppendLine($"**Extends:** `{cls.BaseClass}`  ");
             if (cls.ImplementedInterfaces.Count > 0)
@@ -74,7 +79,8 @@ public class CodeAnalysisService : ICodeAnalysisService
                         p.DefaultValue is not null ? $"{p.Type} {p.Name} = {p.DefaultValue}" : $"{p.Type} {p.Name}"));
                     var prefix = method.IsAsync ? "async " : "";
                     var staticMod = method.IsStatic ? "static " : "";
-                    sb.AppendLine($"- `{prefix}{staticMod}{method.ReturnType} {method.Name}({paramStr})`");
+                    sb.AppendLine($"- `{prefix}{staticMod}{method.ReturnType} {method.Name}({paramStr})`"
+                        + (method.Summary is not null ? $" — {method.Summary}" : ""));
                 }
                 sb.AppendLine();
             }
@@ -114,94 +120,194 @@ public class CodeAnalysisService : ICodeAnalysisService
         return sb.ToString();
     }
 
+    // Roslyn-backed C# analysis. Replaces the previous regex engine, which
+    // missed records/structs, mis-attributed methods in nested/multi-class
+    // files (it appended every method to the most-recent class), missed
+    // expression-bodied members, and could not read XML doc comments. The
+    // syntax tree owns each member under its declaring type, so attribution is
+    // exact. (epic #243 / story #247)
     internal static void AnalyzeCSharp(string content, CodeAnalysisResult result)
     {
-        // Classes
-        foreach (Match m in Regex.Matches(content,
-            @"(public|internal)\s+(abstract\s+|static\s+|sealed\s+)*class\s+(\w+)(?:\s*:\s*([^{]+))?"))
+        var root = CSharpSyntaxTree.ParseText(content).GetRoot();
+
+        // DescendantNodes yields nested types too; each type's Members contains
+        // only its *direct* members, so nested-type members are attributed to
+        // the nested type rather than leaking to the outer one.
+        foreach (var node in root.DescendantNodes())
         {
-            var cls = new ApiClass { Name = m.Groups[3].Value };
-            if (m.Groups[4].Success)
+            switch (node)
             {
-                var bases = m.Groups[4].Value.Split(',').Select(b => b.Trim()).ToList();
-                if (bases.Count > 0 && !bases[0].StartsWith("I"))
-                    cls.BaseClass = bases[0];
-                cls.ImplementedInterfaces = bases.Where(b => b.StartsWith("I") && b.Length > 1 && char.IsUpper(b[1])).ToList();
+                case InterfaceDeclarationSyntax iface:
+                    result.Interfaces.Add(BuildInterface(iface));
+                    break;
+                // RecordDeclarationSyntax covers both `record` and `record struct`.
+                case RecordDeclarationSyntax rec:
+                    result.Classes.Add(BuildClass(rec, rec.ParameterList));
+                    break;
+                case ClassDeclarationSyntax cls:
+                    result.Classes.Add(BuildClass(cls, parameterList: null));
+                    break;
+                case StructDeclarationSyntax st:
+                    result.Classes.Add(BuildClass(st, parameterList: null));
+                    break;
+                case EnumDeclarationSyntax en:
+                    result.Enums.Add(BuildEnum(en));
+                    break;
             }
-            result.Classes.Add(cls);
         }
+    }
 
-        // Interfaces
-        foreach (Match m in Regex.Matches(content,
-            @"(public|internal)\s+interface\s+(I\w+)"))
+    private static ApiClass BuildClass(TypeDeclarationSyntax type, ParameterListSyntax? parameterList)
+    {
+        var cls = new ApiClass { Name = type.Identifier.Text, Summary = GetSummary(type) };
+        SplitBaseList(type.BaseList, b => cls.BaseClass = b, cls.ImplementedInterfaces);
+
+        // Positional record parameters become public init-only properties.
+        if (parameterList is not null)
         {
-            result.Interfaces.Add(new ApiInterface { Name = m.Groups[2].Value });
-        }
-
-        // Public methods
-        foreach (Match m in Regex.Matches(content,
-            @"(public|protected|internal)\s+(static\s+)?(async\s+)?([\w<>\[\],\s\?]+?)\s+(\w+)\s*\(([^)]*)\)"))
-        {
-            var method = new ApiMethod
+            foreach (var p in parameterList.Parameters)
             {
-                Name = m.Groups[5].Value,
-                ReturnType = m.Groups[4].Value.Trim(),
-                AccessModifier = m.Groups[1].Value,
-                IsStatic = m.Groups[2].Success,
-                IsAsync = m.Groups[3].Success
-            };
-
-            if (m.Groups[6].Success && !string.IsNullOrWhiteSpace(m.Groups[6].Value))
-            {
-                foreach (var param in SplitParameters(m.Groups[6].Value))
+                cls.Properties.Add(new ApiProperty
                 {
-                    var parts = param.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                    if (parts.Length >= 2)
+                    Name = p.Identifier.Text,
+                    Type = p.Type?.ToString() ?? "var",
+                    AccessModifier = "public",
+                    HasGetter = true,
+                    HasSetter = false
+                });
+            }
+        }
+
+        AddMembers(type.Members, cls.Methods, cls.Properties, interfaceDefaults: false);
+        return cls;
+    }
+
+    private static ApiInterface BuildInterface(InterfaceDeclarationSyntax type)
+    {
+        var iface = new ApiInterface { Name = type.Identifier.Text, Summary = GetSummary(type) };
+        AddMembers(type.Members, iface.Methods, iface.Properties, interfaceDefaults: true);
+        return iface;
+    }
+
+    private static ApiEnum BuildEnum(EnumDeclarationSyntax type) => new()
+    {
+        Name = type.Identifier.Text,
+        Summary = GetSummary(type),
+        Values = type.Members.Select(m => m.Identifier.Text).ToList()
+    };
+
+    private static void AddMembers(
+        SyntaxList<MemberDeclarationSyntax> members,
+        List<ApiMethod> methods, List<ApiProperty> properties, bool interfaceDefaults)
+    {
+        foreach (var member in members)
+        {
+            switch (member)
+            {
+                case MethodDeclarationSyntax m:
+                {
+                    var access = Accessibility(m.Modifiers, interfaceDefaults);
+                    if (IsPrivate(access)) break;
+                    var method = new ApiMethod
+                    {
+                        Name = m.Identifier.Text,
+                        ReturnType = m.ReturnType.ToString(),
+                        AccessModifier = access,
+                        IsStatic = m.Modifiers.Any(SyntaxKind.StaticKeyword),
+                        IsAsync = m.Modifiers.Any(SyntaxKind.AsyncKeyword),
+                        Summary = GetSummary(m)
+                    };
+                    foreach (var p in m.ParameterList.Parameters)
                     {
                         method.Parameters.Add(new ApiParameter
                         {
-                            Type = string.Join(" ", parts[..^1]),
-                            Name = parts[^1].TrimEnd(',')
+                            Name = p.Identifier.Text,
+                            Type = p.Type?.ToString() ?? "var",
+                            DefaultValue = p.Default?.Value.ToString()
                         });
                     }
+                    methods.Add(method);
+                    break;
+                }
+                case PropertyDeclarationSyntax p:
+                {
+                    var access = Accessibility(p.Modifiers, interfaceDefaults);
+                    if (IsPrivate(access)) break;
+                    // Expression-bodied properties (`=> ...`) are getter-only.
+                    var hasSetter = p.ExpressionBody is null &&
+                        (p.AccessorList?.Accessors.Any(a => a.IsKind(SyntaxKind.SetAccessorDeclaration)
+                            || a.IsKind(SyntaxKind.InitAccessorDeclaration)) ?? false);
+                    properties.Add(new ApiProperty
+                    {
+                        Name = p.Identifier.Text,
+                        Type = p.Type.ToString(),
+                        AccessModifier = access,
+                        HasGetter = true,
+                        HasSetter = hasSetter,
+                        Summary = GetSummary(p)
+                    });
+                    break;
                 }
             }
-
-            // Attach to most recent class if any
-            if (result.Classes.Count > 0)
-                result.Classes[^1].Methods.Add(method);
         }
+    }
 
-        // Public properties
-        foreach (Match m in Regex.Matches(content,
-            @"(public|protected|internal)\s+(required\s+)?([\w<>\[\],\?\s]+?)\s+(\w+)\s*\{"))
+    // Splits a base list into the base class (first non-interface entry) and
+    // interfaces. Without a full semantic model a single file cannot resolve
+    // whether a base type is a class or interface, so we use the .NET naming
+    // convention (interfaces are `I` + UpperCamelCase). C# also requires the
+    // base class, if present, to appear first.
+    private static void SplitBaseList(BaseListSyntax? baseList, Action<string> setBaseClass, List<string> interfaces)
+    {
+        if (baseList is null) return;
+        foreach (var entry in baseList.Types)
         {
-            var name = m.Groups[4].Value;
-            if (name is "class" or "interface" or "enum" or "struct" or "void") continue;
-
-            var prop = new ApiProperty
-            {
-                Name = name,
-                Type = m.Groups[3].Value.Trim(),
-                AccessModifier = m.Groups[1].Value,
-                HasGetter = true,
-                HasSetter = true
-            };
-
-            if (result.Classes.Count > 0)
-                result.Classes[^1].Properties.Add(prop);
+            var name = entry.Type.ToString();
+            if (LooksLikeInterface(name))
+                interfaces.Add(name);
+            else
+                setBaseClass(name);
         }
+    }
 
-        // Enums
-        foreach (Match m in Regex.Matches(content,
-            @"(public|internal)\s+enum\s+(\w+)\s*\{([^}]+)\}"))
-        {
-            var values = m.Groups[3].Value.Split(',')
-                .Select(v => v.Trim().Split('=')[0].Trim())
-                .Where(v => !string.IsNullOrWhiteSpace(v))
-                .ToList();
-            result.Enums.Add(new ApiEnum { Name = m.Groups[2].Value, Values = values });
-        }
+    private static bool LooksLikeInterface(string name) =>
+        name.Length > 1 && name[0] == 'I' && char.IsUpper(name[1]);
+
+    private static string Accessibility(SyntaxTokenList modifiers, bool interfaceDefaults)
+    {
+        var isPublic = modifiers.Any(SyntaxKind.PublicKeyword);
+        var isProtected = modifiers.Any(SyntaxKind.ProtectedKeyword);
+        var isInternal = modifiers.Any(SyntaxKind.InternalKeyword);
+        var isPrivate = modifiers.Any(SyntaxKind.PrivateKeyword);
+
+        if (isProtected && isInternal) return "protected internal";
+        if (isPrivate && isProtected) return "private protected";
+        if (isPublic) return "public";
+        if (isProtected) return "protected";
+        if (isInternal) return "internal";
+        if (isPrivate) return "private";
+        // No explicit modifier: interface members are public, type members private.
+        return interfaceDefaults ? "public" : "private";
+    }
+
+    private static bool IsPrivate(string access) => access is "private" or "private protected";
+
+    private static string? GetSummary(SyntaxNode node)
+    {
+        var doc = node.GetLeadingTrivia()
+            .Select(t => t.GetStructure())
+            .OfType<DocumentationCommentTriviaSyntax>()
+            .FirstOrDefault();
+
+        var summary = doc?.Content.OfType<XmlElementSyntax>()
+            .FirstOrDefault(e => e.StartTag.Name.LocalName.Text == "summary");
+        if (summary is null) return null;
+
+        // Strip `///` exteriors and collapse whitespace into a single line.
+        var text = summary.Content.ToFullString();
+        text = Regex.Replace(text, @"///", " ");
+        text = Regex.Replace(text, @"\s+", " ").Trim();
+        return string.IsNullOrEmpty(text) ? null : text;
     }
 
     internal static void AnalyzeTypeScript(string content, CodeAnalysisResult result)
@@ -344,34 +450,5 @@ public class CodeAnalysisService : ICodeAnalysisService
                 .ToList();
             result.Enums.Add(new ApiEnum { Name = m.Groups[1].Value, Values = values });
         }
-    }
-
-    private static List<string> SplitParameters(string paramString)
-    {
-        // Simple split handling generic types like List<string>
-        var result = new List<string>();
-        var depth = 0;
-        var current = new StringBuilder();
-
-        foreach (var ch in paramString)
-        {
-            if (ch == '<') depth++;
-            else if (ch == '>') depth--;
-
-            if (ch == ',' && depth == 0)
-            {
-                result.Add(current.ToString());
-                current.Clear();
-            }
-            else
-            {
-                current.Append(ch);
-            }
-        }
-
-        if (current.Length > 0)
-            result.Add(current.ToString());
-
-        return result;
     }
 }

--- a/tests/Andy.CodeIndex.Tests.Unit/Services/CSharpRoslynAnalysisTests.cs
+++ b/tests/Andy.CodeIndex.Tests.Unit/Services/CSharpRoslynAnalysisTests.cs
@@ -1,0 +1,210 @@
+using Andy.CodeIndex.Infrastructure.Services;
+using FluentAssertions;
+
+namespace Andy.CodeIndex.Tests.Unit.Services;
+
+/// <summary>
+/// Covers the C# constructs the previous regex engine got wrong (epic #243 /
+/// story #247): records, structs, nested/multiple classes, expression-bodied
+/// members, generics, parameter defaults, interface members, and XML docs.
+/// </summary>
+public class CSharpRoslynAnalysisTests
+{
+    private readonly CodeAnalysisService _service = new();
+
+    [Fact]
+    public void Records_AreExtracted_WithPositionalParametersAsProperties()
+    {
+        var code = "public record Money(decimal Amount, string Currency);";
+
+        var result = _service.Analyze(code, "Money.cs", "csharp");
+
+        result.Classes.Should().ContainSingle(c => c.Name == "Money");
+        var money = result.Classes.Single();
+        money.Properties.Select(p => p.Name).Should().Contain(new[] { "Amount", "Currency" });
+        money.Properties.Should().OnlyContain(p => p.HasGetter && !p.HasSetter);
+    }
+
+    [Fact]
+    public void RecordStruct_IsExtracted()
+    {
+        var code = "public record struct Coordinate(double Lat, double Lng);";
+
+        var result = _service.Analyze(code, "Coordinate.cs", "csharp");
+
+        result.Classes.Should().ContainSingle(c => c.Name == "Coordinate");
+        result.Classes.Single().Properties.Select(p => p.Name).Should().Equal("Lat", "Lng");
+    }
+
+    [Fact]
+    public void Struct_IsExtracted_WithMembers()
+    {
+        var code = @"
+public struct Point
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+    public double Distance() => 0.0;
+}";
+        var result = _service.Analyze(code, "Point.cs", "csharp");
+
+        var point = result.Classes.Should().ContainSingle(c => c.Name == "Point").Subject;
+        point.Properties.Select(p => p.Name).Should().Equal("X", "Y");
+        point.Methods.Should().ContainSingle(m => m.Name == "Distance");
+    }
+
+    [Fact]
+    public void NestedClass_MethodsAttributedToDeclaringType_NotMostRecentClass()
+    {
+        // The regex engine appended every method to result.Classes[^1], so the
+        // outer method leaked onto the nested class. Roslyn attributes correctly.
+        var code = @"
+public class Outer
+{
+    public void OuterMethod() { }
+
+    public class Inner
+    {
+        public void InnerMethod() { }
+    }
+}";
+        var result = _service.Analyze(code, "Outer.cs", "csharp");
+
+        var outer = result.Classes.Should().ContainSingle(c => c.Name == "Outer").Subject;
+        var inner = result.Classes.Should().ContainSingle(c => c.Name == "Inner").Subject;
+
+        outer.Methods.Select(m => m.Name).Should().Equal("OuterMethod");
+        inner.Methods.Select(m => m.Name).Should().Equal("InnerMethod");
+    }
+
+    [Fact]
+    public void MultipleTopLevelClasses_EachOwnTheirMethods()
+    {
+        var code = @"
+public class A { public void Ay() { } }
+public class B { public void Bee() { } }";
+        var result = _service.Analyze(code, "AB.cs", "csharp");
+
+        result.Classes.Single(c => c.Name == "A").Methods.Select(m => m.Name).Should().Equal("Ay");
+        result.Classes.Single(c => c.Name == "B").Methods.Select(m => m.Name).Should().Equal("Bee");
+    }
+
+    [Fact]
+    public void ExpressionBodiedMembers_AreExtracted_GetterOnlyProperty()
+    {
+        var code = @"
+public class Calc
+{
+    public int Total => 42;
+    public string Describe(int n) => n.ToString();
+}";
+        var result = _service.Analyze(code, "Calc.cs", "csharp");
+
+        var calc = result.Classes.Single();
+        var total = calc.Properties.Should().ContainSingle(p => p.Name == "Total").Subject;
+        total.HasGetter.Should().BeTrue();
+        total.HasSetter.Should().BeFalse();
+        calc.Methods.Should().ContainSingle(m => m.Name == "Describe");
+    }
+
+    [Fact]
+    public void InitOnlyProperty_HasSetterTrue_PrivateMembersExcluded()
+    {
+        var code = @"
+public class Account
+{
+    public string Id { get; init; }
+    public decimal Balance { get; set; }
+    private string Secret { get; set; }
+    private void Internal() { }
+}";
+        var result = _service.Analyze(code, "Account.cs", "csharp");
+
+        var acc = result.Classes.Single();
+        acc.Properties.Should().ContainSingle(p => p.Name == "Id").Which.HasSetter.Should().BeTrue();
+        acc.Properties.Select(p => p.Name).Should().NotContain("Secret");
+        acc.Methods.Select(m => m.Name).Should().NotContain("Internal");
+    }
+
+    [Fact]
+    public void GenericMethod_RendersParameterTypes_AndDefaults()
+    {
+        var code = @"
+public class Repo
+{
+    public System.Threading.Tasks.Task<System.Collections.Generic.List<T>> GetAsync<T>(System.Collections.Generic.IEnumerable<T> items, int limit = 10)
+    {
+        return null;
+    }
+}";
+        var result = _service.Analyze(code, "Repo.cs", "csharp");
+
+        var method = result.Classes.Single().Methods.Single(m => m.Name == "GetAsync");
+        method.Parameters.Should().HaveCount(2);
+        method.Parameters[0].Name.Should().Be("items");
+        method.Parameters[0].Type.Should().Contain("IEnumerable<T>");
+        method.Parameters[1].Name.Should().Be("limit");
+        method.Parameters[1].DefaultValue.Should().Be("10");
+    }
+
+    [Fact]
+    public void InterfaceMembers_ArePopulated()
+    {
+        var code = @"
+public interface IRepository
+{
+    string Name { get; }
+    System.Threading.Tasks.Task SaveAsync(int id);
+}";
+        var result = _service.Analyze(code, "IRepository.cs", "csharp");
+
+        var iface = result.Interfaces.Should().ContainSingle(i => i.Name == "IRepository").Subject;
+        iface.Methods.Should().ContainSingle(m => m.Name == "SaveAsync");
+        iface.Properties.Should().ContainSingle(p => p.Name == "Name");
+    }
+
+    [Fact]
+    public void XmlDocSummaries_AreCaptured_ForClassAndMethod()
+    {
+        var code = @"
+/// <summary>
+/// Provides access to widgets.
+/// </summary>
+public class WidgetService
+{
+    /// <summary>Gets a widget by id.</summary>
+    public string Get(int id) => """";
+}";
+        var result = _service.Analyze(code, "WidgetService.cs", "csharp");
+
+        var cls = result.Classes.Single();
+        cls.Summary.Should().Be("Provides access to widgets.");
+        cls.Methods.Single(m => m.Name == "Get").Summary.Should().Be("Gets a widget by id.");
+    }
+
+    [Fact]
+    public void GenerateApiDocs_IncludesXmlSummary()
+    {
+        var code = @"
+/// <summary>A typed cache.</summary>
+public class Cache { }";
+        var result = _service.Analyze(code, "Cache.cs", "csharp");
+
+        var docs = _service.GenerateApiDocs(result);
+
+        docs.Should().Contain("A typed cache.");
+    }
+
+    [Fact]
+    public void MalformedCode_DoesNotThrow_BestEffortExtraction()
+    {
+        // Roslyn parses with error recovery; the analyzer must not throw.
+        var code = "public class Broken { public void Oops( { ";
+
+        var act = () => _service.Analyze(code, "Broken.cs", "csharp");
+
+        act.Should().NotThrow();
+        var result = act();
+        result.Classes.Should().ContainSingle(c => c.Name == "Broken");
+    }
+}


### PR DESCRIPTION
First story of **epic #243 — replace the regex "AST" with real parsers**. Swaps the regex-based C# analyzer for a Roslyn syntax-tree walk, making the README's "AST-based API documentation" claim true for C#.

## Bugs fixed (each with a new test in `CSharpRoslynAnalysisTests`)
- **records / record structs** — were missed entirely; positional params now become public init-only properties
- **structs** — were missed
- **nested / multiple classes** — the regex appended every method to the most-recent class; members are now attributed to their declaring type
- **expression-bodied members** (`int X => …`, `string M() => …`) — were missed
- **generics & defaults** — generic parameter/return types and parameter default values captured
- **interface members** — methods + properties now populated (the doc-gen loop for them was previously dead)
- **private members excluded**; `init` accessors count as a setter
- **XML `<summary>` docs** captured (new `Summary` field) and rendered in `GenerateApiDocs` — impossible with regex
- **malformed source** no longer breaks extraction (Roslyn error recovery)

## Notes
- `Microsoft.CodeAnalysis.CSharp` pinned to **4.5.0** to match EF Core Design 8.0.11's transitive requirement (avoids NU1107/NU1608 under `TreatWarningsAsErrors`).
- TypeScript/JavaScript/Python/Go/Java remain regex-based pending **#248**.

## Testing
- Full solution builds clean (0 warnings).
- Unit suite: **775 passed** (+12 new), the only 4 failures being pre-existing git-backed handler/discovery tests that also fail on `main` (verified).
- The 15 existing `CodeAnalysisServiceTests` still pass unchanged.

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)