### PR TITLE
Managed Python/JS/TS parsers (story #248)

### DIFF
--- a/src/Andy.CodeIndex.Application/Interfaces/ICodeAnalysisService.cs
+++ b/src/Andy.CodeIndex.Application/Interfaces/ICodeAnalysisService.cs
@@ -69,6 +69,7 @@ public class ApiFunction
     public required string ReturnType { get; set; }
     public List<ApiParameter> Parameters { get; set; } = [];
     public bool IsExported { get; set; }
+    public bool IsAsync { get; set; }
     public string? Summary { get; set; }
 }
 

--- a/src/Andy.CodeIndex.Infrastructure/Andy.CodeIndex.Infrastructure.csproj
+++ b/src/Andy.CodeIndex.Infrastructure/Andy.CodeIndex.Infrastructure.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Acornima" Version="1.6.2" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.11" />
     <!-- Pinned to 4.5.0 to match the version EF Core Design 8.0.11 transitively
          requires (Microsoft.CodeAnalysis.CSharp.Workspaces 4.5.0 → Common 4.5.0). -->

--- a/src/Andy.CodeIndex.Infrastructure/Services/CodeAnalysisService.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Services/CodeAnalysisService.cs
@@ -1,5 +1,7 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Acornima;
+using Acornima.Ast;
 using Andy.CodeIndex.Application.Interfaces;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -25,8 +27,10 @@ public class CodeAnalysisService : ICodeAnalysisService
             case "csharp":
                 AnalyzeCSharp(content, result);
                 break;
-            case "typescript":
             case "javascript":
+                AnalyzeJavaScript(content, result);
+                break;
+            case "typescript":
                 AnalyzeTypeScript(content, result);
                 break;
             case "python":
@@ -310,6 +314,125 @@ public class CodeAnalysisService : ICodeAnalysisService
         return string.IsNullOrEmpty(text) ? null : text;
     }
 
+    // Acornima-backed JavaScript analysis (real AST). Replaces routing JS
+    // through the TypeScript regex, which missed arrow-function exports,
+    // `export default`, and class methods entirely. Acornima parses ECMAScript +
+    // JSX but not TypeScript type syntax, so .ts stays on the heuristic path.
+    // (epic #243 / story #248)
+    internal static void AnalyzeJavaScript(string content, CodeAnalysisResult result)
+    {
+        Module program;
+        try
+        {
+            program = new Parser().ParseModule(content);
+        }
+        catch (Exception)
+        {
+            // Acornima throws on input it cannot parse (e.g. TS-flavored JS);
+            // fall back to the heuristic analyzer so we still extract something.
+            AnalyzeTypeScript(content, result);
+            return;
+        }
+
+        foreach (var stmt in program.Body)
+        {
+            switch (stmt)
+            {
+                case ExportNamedDeclaration { Declaration: { } named }:
+                    AddJsDeclaration(named, result, exported: true);
+                    break;
+                case ExportDefaultDeclaration def:
+                    AddJsDeclaration(def.Declaration, result, exported: true);
+                    break;
+                default:
+                    AddJsDeclaration(stmt, result, exported: false);
+                    break;
+            }
+        }
+    }
+
+    private static void AddJsDeclaration(Node node, CodeAnalysisResult result, bool exported)
+    {
+        switch (node)
+        {
+            case ClassDeclaration cls:
+                result.Classes.Add(BuildJsClass(cls));
+                break;
+            case FunctionDeclaration fn:
+                result.Functions.Add(new ApiFunction
+                {
+                    Name = fn.Id?.Name ?? "default",
+                    ReturnType = "any",
+                    IsExported = exported,
+                    IsAsync = fn.Async,
+                    Parameters = JsParameters(fn.Params)
+                });
+                break;
+            case VariableDeclaration vd:
+                foreach (var d in vd.Declarations)
+                {
+                    // export const foo = () => {} / = function () {}
+                    if (d.Init is IFunction fnExpr && d.Id is Identifier id)
+                    {
+                        result.Functions.Add(new ApiFunction
+                        {
+                            Name = id.Name,
+                            ReturnType = "any",
+                            IsExported = exported,
+                            IsAsync = fnExpr.Async,
+                            Parameters = JsParameters(fnExpr.Params)
+                        });
+                    }
+                }
+                break;
+        }
+    }
+
+    private static ApiClass BuildJsClass(ClassDeclaration cls)
+    {
+        var apiClass = new ApiClass { Name = cls.Id?.Name ?? "default" };
+        if (cls.SuperClass is Identifier super)
+            apiClass.BaseClass = super.Name;
+
+        foreach (var member in cls.Body.Body)
+        {
+            if (member is MethodDefinition { Key: Identifier key } md && md.Value is { } fn)
+            {
+                apiClass.Methods.Add(new ApiMethod
+                {
+                    Name = key.Name,
+                    ReturnType = "any",
+                    AccessModifier = "public",
+                    IsStatic = md.Static,
+                    IsAsync = fn.Async,
+                    Parameters = JsParameters(fn.Params)
+                });
+            }
+        }
+        return apiClass;
+    }
+
+    private static List<ApiParameter> JsParameters(in NodeList<Node> parameters)
+    {
+        var list = new List<ApiParameter>();
+        foreach (var p in parameters)
+        {
+            switch (p)
+            {
+                case Identifier id:
+                    list.Add(new ApiParameter { Name = id.Name, Type = "any" });
+                    break;
+                case AssignmentPattern { Left: Identifier lid } ap:
+                    list.Add(new ApiParameter { Name = lid.Name, Type = "any", DefaultValue = ap.Right.ToString() });
+                    break;
+                case RestElement { Argument: Identifier rid }:
+                    list.Add(new ApiParameter { Name = "..." + rid.Name, Type = "any" });
+                    break;
+            }
+        }
+        return list;
+    }
+
     internal static void AnalyzeTypeScript(string content, CodeAnalysisResult result)
     {
         // Exported classes
@@ -352,38 +475,200 @@ public class CodeAnalysisService : ICodeAnalysisService
                 .ToList();
             result.Enums.Add(new ApiEnum { Name = m.Groups[1].Value, Values = values });
         }
+
+        // Exported arrow-function consts: `export const f = (...) => ...` and
+        // `export const f = async (...) => ...`. Previously missed entirely
+        // despite being the dominant modern export style (story #248).
+        foreach (Match m in Regex.Matches(content,
+            @"export\s+const\s+(\w+)\s*(?::\s*[^=\n]+?)?=\s*(?:async\s+)?(?:\([^)]*\)|[\w$]+)[^=\n;{]*=>"))
+        {
+            if (result.Functions.Any(f => f.Name == m.Groups[1].Value)) continue;
+            result.Functions.Add(new ApiFunction { Name = m.Groups[1].Value, ReturnType = "any", IsExported = true });
+        }
+
+        // export default class / function
+        foreach (Match m in Regex.Matches(content,
+            @"export\s+default\s+(?:abstract\s+)?class\s+(\w+)(?:\s+extends\s+(\w+))?"))
+        {
+            if (result.Classes.Any(c => c.Name == m.Groups[1].Value)) continue;
+            result.Classes.Add(new ApiClass { Name = m.Groups[1].Value, BaseClass = m.Groups[2].Success ? m.Groups[2].Value : null });
+        }
+        foreach (Match m in Regex.Matches(content,
+            @"export\s+default\s+(?:async\s+)?function\s+(\w+)"))
+        {
+            if (result.Functions.Any(f => f.Name == m.Groups[1].Value)) continue;
+            result.Functions.Add(new ApiFunction { Name = m.Groups[1].Value, ReturnType = "any", IsExported = true });
+        }
     }
 
+    // Indentation-aware Python analysis. The previous regex only matched
+    // column-0 `class`/`def`, so it dropped every method inside a class and
+    // every `async def`. This line scanner tracks the enclosing class by indent
+    // and understands async defs, decorators (@staticmethod/@classmethod →
+    // static, @property → property), and return annotations. (story #248)
     internal static void AnalyzePython(string content, CodeAnalysisResult result)
     {
-        // Classes
-        foreach (Match m in Regex.Matches(content,
-            @"^class\s+(\w+)(?:\(([^)]+)\))?:", RegexOptions.Multiline))
+        var lines = content.Replace("\r\n", "\n").Replace("\t", "    ").Split('\n');
+        ApiClass? currentClass = null;
+        var classIndent = -1;
+        var decorators = new List<string>();
+
+        foreach (var line in lines)
         {
-            var cls = new ApiClass { Name = m.Groups[1].Value };
-            if (m.Groups[2].Success)
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            var trimmed = line.Trim();
+            var indent = line.Length - line.TrimStart(' ').Length;
+
+            // Dedent past the class body closes the class (decorators belong to
+            // the member that follows, so they don't trigger a close).
+            if (currentClass is not null && indent <= classIndent && !trimmed.StartsWith('@'))
             {
-                var bases = m.Groups[2].Value.Split(',').Select(b => b.Trim()).ToList();
-                if (bases.Count > 0 && bases[0] != "object")
-                    cls.BaseClass = bases[0];
+                currentClass = null;
+                classIndent = -1;
             }
-            result.Classes.Add(cls);
-        }
 
-        // Functions (module-level)
-        foreach (Match m in Regex.Matches(content,
-            @"^def\s+(\w+)\s*\(([^)]*)\)(?:\s*->\s*([\w\[\],\s]+))?:", RegexOptions.Multiline))
-        {
-            var name = m.Groups[1].Value;
-            if (name.StartsWith('_')) continue; // Skip private
-
-            result.Functions.Add(new ApiFunction
+            if (trimmed.StartsWith('@'))
             {
-                Name = name,
-                ReturnType = m.Groups[3].Success ? m.Groups[3].Value.Trim() : "None",
-                IsExported = true
-            });
+                decorators.Add(trimmed.TrimStart('@'));
+                continue;
+            }
+
+            var classMatch = Regex.Match(trimmed, @"^class\s+(\w+)\s*(?:\(([^)]*)\))?\s*:");
+            if (classMatch.Success)
+            {
+                var cls = new ApiClass { Name = classMatch.Groups[1].Value };
+                if (classMatch.Groups[2].Success)
+                {
+                    var bases = classMatch.Groups[2].Value.Split(',')
+                        .Select(b => b.Trim()).Where(b => b.Length > 0).ToList();
+                    if (bases.Count > 0 && bases[0] != "object")
+                        cls.BaseClass = bases[0];
+                }
+                result.Classes.Add(cls);
+                currentClass = cls;
+                classIndent = indent;
+                decorators.Clear();
+                continue;
+            }
+
+            var defMatch = Regex.Match(trimmed, @"^(async\s+)?def\s+(\w+)\s*\((.*)\)\s*(?:->\s*(.+?))?\s*:");
+            if (defMatch.Success)
+            {
+                var isAsync = defMatch.Groups[1].Success;
+                var name = defMatch.Groups[2].Value;
+                var returnType = defMatch.Groups[4].Success ? defMatch.Groups[4].Value.Trim() : "None";
+                var isStatic = decorators.Any(d => d.StartsWith("staticmethod") || d.StartsWith("classmethod"));
+                var isProperty = decorators.Any(d => d.StartsWith("property"));
+
+                if (currentClass is not null && indent > classIndent)
+                {
+                    if (isProperty && IsPublicPy(name))
+                    {
+                        currentClass.Properties.Add(new ApiProperty
+                        {
+                            Name = name, Type = returnType, AccessModifier = "public",
+                            HasGetter = true, HasSetter = false
+                        });
+                    }
+                    else if (IncludePyMember(name) && !isProperty)
+                    {
+                        currentClass.Methods.Add(new ApiMethod
+                        {
+                            Name = name, ReturnType = returnType, AccessModifier = "public",
+                            IsAsync = isAsync, IsStatic = isStatic,
+                            Parameters = PyParameters(defMatch.Groups[3].Value, skipFirst: !isStatic)
+                        });
+                    }
+                }
+                else if (indent == 0 && !name.StartsWith('_'))
+                {
+                    result.Functions.Add(new ApiFunction
+                    {
+                        Name = name, ReturnType = returnType, IsExported = true, IsAsync = isAsync,
+                        Parameters = PyParameters(defMatch.Groups[3].Value, skipFirst: false)
+                    });
+                }
+
+                decorators.Clear();
+                continue;
+            }
+
+            decorators.Clear();
         }
+    }
+
+    // Include public methods and dunders (e.g. __init__); skip single-underscore
+    // "private" members.
+    private static bool IncludePyMember(string name) =>
+        !name.StartsWith('_') || (name.StartsWith("__") && name.EndsWith("__"));
+
+    private static bool IsPublicPy(string name) => !name.StartsWith('_');
+
+    private static List<ApiParameter> PyParameters(string paramString, bool skipFirst)
+    {
+        var list = new List<ApiParameter>();
+        var first = true;
+        foreach (var part in SplitTopLevel(paramString, ','))
+        {
+            var token = part.Trim();
+            if (token.Length == 0 || token is "*" or "/") continue;
+            if (skipFirst && first && (token == "self" || token == "cls"))
+            {
+                first = false;
+                continue;
+            }
+            first = false;
+
+            var name = token.TrimStart('*');
+            string? type = null;
+            string? def = null;
+
+            var eq = name.IndexOf('=');
+            if (eq >= 0)
+            {
+                def = name[(eq + 1)..].Trim();
+                name = name[..eq];
+            }
+            var colon = name.IndexOf(':');
+            if (colon >= 0)
+            {
+                type = name[(colon + 1)..].Trim();
+                name = name[..colon];
+            }
+            name = name.Trim();
+            if (name.Length == 0) continue;
+
+            list.Add(new ApiParameter { Name = name, Type = type ?? "Any", DefaultValue = def });
+        }
+        return list;
+    }
+
+    // Splits on a separator that is not nested inside (), [], {} or <>.
+    private static List<string> SplitTopLevel(string text, char sep)
+    {
+        var result = new List<string>();
+        var depth = 0;
+        var current = new StringBuilder();
+        foreach (var ch in text)
+        {
+            switch (ch)
+            {
+                case '(' or '[' or '{' or '<': depth++; break;
+                case ')' or ']' or '}' or '>': depth--; break;
+            }
+            if (ch == sep && depth <= 0)
+            {
+                result.Add(current.ToString());
+                current.Clear();
+            }
+            else
+            {
+                current.Append(ch);
+            }
+        }
+        if (current.Length > 0) result.Add(current.ToString());
+        return result;
     }
 
     internal static void AnalyzeGo(string content, CodeAnalysisResult result)

--- a/tests/Andy.CodeIndex.Tests.Unit/Services/ManagedParserAnalysisTests.cs
+++ b/tests/Andy.CodeIndex.Tests.Unit/Services/ManagedParserAnalysisTests.cs
@@ -1,0 +1,173 @@
+using Andy.CodeIndex.Infrastructure.Services;
+using FluentAssertions;
+
+namespace Andy.CodeIndex.Tests.Unit.Services;
+
+/// <summary>
+/// Covers the managed JS/Python/TS analyzers added in story #248: JavaScript via
+/// the Acornima AST, Python via an indentation-aware scanner, and TypeScript
+/// heuristic improvements (arrow exports, export default).
+/// </summary>
+public class ManagedParserAnalysisTests
+{
+    private readonly CodeAnalysisService _service = new();
+
+    // ---------- JavaScript (Acornima AST) ----------
+
+    [Fact]
+    public void JavaScript_ExtractsClassWithMethods_BaseClass_StaticAndAsync()
+    {
+        var code = @"
+export class Widget extends Base {
+  constructor(id) { this.id = id; }
+  async load(url) { return fetch(url); }
+  static create() { return new Widget(); }
+}
+";
+        var result = _service.Analyze(code, "widget.js", "javascript");
+
+        var widget = result.Classes.Should().ContainSingle(c => c.Name == "Widget").Subject;
+        widget.BaseClass.Should().Be("Base");
+        widget.Methods.Should().ContainSingle(m => m.Name == "load").Which.IsAsync.Should().BeTrue();
+        widget.Methods.Should().ContainSingle(m => m.Name == "create").Which.IsStatic.Should().BeTrue();
+    }
+
+    [Fact]
+    public void JavaScript_ExtractsArrowFunctionExports()
+    {
+        // The previous regex path missed these entirely.
+        var code = @"
+export const make = (x) => x * 2;
+export const fetchAsync = async (u) => await fetch(u);
+export function build(a, b) { return a + b; }
+";
+        var result = _service.Analyze(code, "fns.js", "javascript");
+
+        result.Functions.Select(f => f.Name).Should().Contain(new[] { "make", "fetchAsync", "build" });
+        result.Functions.Should().OnlyContain(f => f.IsExported);
+        result.Functions.Single(f => f.Name == "build").Parameters.Select(p => p.Name).Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public void JavaScript_ExtractsExportDefaultClassAndFunction()
+    {
+        _service.Analyze("export default class App {}", "app.js", "javascript")
+            .Classes.Should().ContainSingle(c => c.Name == "App");
+
+        _service.Analyze("export default function setup() {}", "setup.js", "javascript")
+            .Functions.Should().ContainSingle(f => f.Name == "setup");
+    }
+
+    [Fact]
+    public void JavaScript_NonExportedTopLevel_IsCaptured_NotMarkedExported()
+    {
+        var result = _service.Analyze("function helper(a) { return a; }", "h.js", "javascript");
+
+        var fn = result.Functions.Should().ContainSingle(f => f.Name == "helper").Subject;
+        fn.IsExported.Should().BeFalse();
+    }
+
+    // ---------- Python (indentation-aware) ----------
+
+    [Fact]
+    public void Python_ExtractsClassMethods_AsyncDef_AndModuleAsyncFunctions()
+    {
+        var code = @"
+class Animal:
+    def __init__(self, name):
+        self.name = name
+
+    async def speak(self, volume=5) -> str:
+        return 'hi'
+
+    def _private(self):
+        pass
+
+def top_level(a, b) -> int:
+    return a + b
+
+async def fetch_data(url):
+    return None
+
+def _hidden():
+    pass
+";
+        var result = _service.Analyze(code, "animal.py", "python");
+
+        var animal = result.Classes.Should().ContainSingle(c => c.Name == "Animal").Subject;
+        animal.Methods.Select(m => m.Name).Should().Contain(new[] { "__init__", "speak" });
+        animal.Methods.Select(m => m.Name).Should().NotContain("_private");
+        animal.Methods.Single(m => m.Name == "speak").IsAsync.Should().BeTrue();
+        // self is dropped; the annotated return type is captured.
+        animal.Methods.Single(m => m.Name == "speak").Parameters.Select(p => p.Name).Should().Equal("volume");
+        animal.Methods.Single(m => m.Name == "speak").ReturnType.Should().Be("str");
+
+        result.Functions.Select(f => f.Name).Should().Contain(new[] { "top_level", "fetch_data" });
+        result.Functions.Select(f => f.Name).Should().NotContain("_hidden");
+        result.Functions.Single(f => f.Name == "fetch_data").IsAsync.Should().BeTrue();
+        result.Functions.Single(f => f.Name == "top_level").Parameters.Select(p => p.Name).Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public void Python_Decorators_PropertyBecomesProperty_StaticmethodMarksStatic()
+    {
+        var code = @"
+class Config:
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @staticmethod
+    def default() -> int:
+        return 0
+";
+        var result = _service.Analyze(code, "config.py", "python");
+
+        var config = result.Classes.Single();
+        config.Properties.Should().ContainSingle(p => p.Name == "name");
+        config.Methods.Should().ContainSingle(m => m.Name == "default").Which.IsStatic.Should().BeTrue();
+        config.Methods.Should().NotContain(m => m.Name == "name");
+    }
+
+    [Fact]
+    public void Python_NestedClassBase_IsCaptured()
+    {
+        var code = @"
+class Base:
+    pass
+
+class Derived(Base):
+    def run(self):
+        pass
+";
+        var result = _service.Analyze(code, "d.py", "python");
+
+        result.Classes.Should().HaveCount(2);
+        result.Classes.Single(c => c.Name == "Derived").BaseClass.Should().Be("Base");
+        result.Classes.Single(c => c.Name == "Derived").Methods.Select(m => m.Name).Should().Equal("run");
+    }
+
+    // ---------- TypeScript (heuristic improvements) ----------
+
+    [Fact]
+    public void TypeScript_ExtractsArrowFunctionExports()
+    {
+        var code = @"
+export const handler = (req: Request): Response => doThing(req);
+export const compute = async (n: number): Promise<number> => n;
+";
+        var result = _service.Analyze(code, "handlers.ts", "typescript");
+
+        result.Functions.Select(f => f.Name).Should().Contain(new[] { "handler", "compute" });
+    }
+
+    [Fact]
+    public void TypeScript_ExtractsExportDefaultClassAndFunction()
+    {
+        _service.Analyze("export default class Page extends Component {}", "page.ts", "typescript")
+            .Classes.Should().ContainSingle(c => c.Name == "Page" && c.BaseClass == "Component");
+
+        _service.Analyze("export default function setup() {}", "s.ts", "typescript")
+            .Functions.Should().ContainSingle(f => f.Name == "setup");
+    }
+}


### PR DESCRIPTION
Second story of **epic #243**. Replaces the regex routing for the non-C# languages with managed parsers — **no native dependencies** (chosen approach), fixing the constructs the review flagged.

## JavaScript — now a real AST (Acornima, pure-.NET acorn/ESTree)
- arrow-function exports (`export const f = () => {}`) — previously missed entirely
- `export default` class and function
- class methods with static/async flags and base class
- non-exported top-level declarations captured (`IsExported=false`)
- unparseable input falls back to the heuristic analyzer

## Python — indentation-aware scanner (replaces column-0-only regex)
- **methods inside classes** (were dropped entirely), attributed by indent
- **`async def`** at module and method level — previously unmatched
- decorators: `@property` → property, `@staticmethod`/`@classmethod` → static
- return annotations + parameters (self/cls dropped); dunders kept, `_private` skipped

## TypeScript — heuristic improvements
Acornima can't parse TS type syntax, so `.ts` stays on the regex path (full TS AST is a **tree-sitter follow-up**). Added the flagged gaps: arrow-function exports and `export default` class/function.

## Notes
- Adds **Acornima 1.6.2** (managed, netstandard2.0) and an `IsAsync` flag on `ApiFunction`.
- C# (Roslyn from #247) and the Go/Java regex analyzers are unchanged.

## Testing
- Full solution builds clean (0 warnings).
- Unit suite **784 passed** (+9 new in `ManagedParserAnalysisTests`; 36 analysis tests total green). The only 4 failures are pre-existing git-backed handler/discovery tests that also fail on `main`.

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)