### PR TITLE
Structure-aware chunking with context prepending (story #249)

### DIFF
--- a/src/Andy.CodeIndex.Application/Interfaces/ICodeAnalysisService.cs
+++ b/src/Andy.CodeIndex.Application/Interfaces/ICodeAnalysisService.cs
@@ -5,7 +5,18 @@ public interface ICodeAnalysisService
     CodeAnalysisResult Analyze(string content, string filePath, string language);
     string GenerateApiDocs(CodeAnalysisResult result);
     bool SupportsLanguage(string language);
+
+    /// <summary>
+    /// Returns the 1-based source line at which each top-level type/method/function
+    /// declaration begins, with a short context label (e.g. "Type.Method"). Used by
+    /// the chunker to align chunk boundaries to declarations instead of arbitrary
+    /// size cuts. Returns an empty list for languages without a structural parser.
+    /// </summary>
+    IReadOnlyList<StructuralBoundary> GetStructuralBoundaries(string content, string language);
 }
+
+/// <summary>A declaration boundary: the line it starts on and an enclosing-context label.</summary>
+public readonly record struct StructuralBoundary(int Line, string Context);
 
 public class CodeAnalysisResult
 {

--- a/src/Andy.CodeIndex.Infrastructure/Services/ChunkingService.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Services/ChunkingService.cs
@@ -9,12 +9,48 @@ public class ChunkingService : IChunkingService
 {
     private static readonly ChunkingOptions DefaultOptions = new();
 
+    // Extensions whose language has a structural parser (Roslyn / Acornima).
+    private static readonly Dictionary<string, string> StructuralLanguagesByExtension =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            [".cs"] = "csharp",
+            [".js"] = "javascript",
+            [".jsx"] = "javascript",
+            [".mjs"] = "javascript",
+            [".cjs"] = "javascript",
+        };
+
+    private readonly ICodeAnalysisService _analysis;
+
+    // Optional dependency so existing `new ChunkingService()` usages (and tests)
+    // keep working; DI supplies the registered analyzer.
+    public ChunkingService(ICodeAnalysisService? analysis = null)
+        => _analysis = analysis ?? new CodeAnalysisService();
+
     public List<CodeChunk> ChunkText(string content, string? filePath = null, ChunkingOptions? options = null)
     {
         if (string.IsNullOrEmpty(content))
             return [];
 
         var opts = options ?? DefaultOptions;
+
+        // Structure-aware path: align chunk starts to declaration boundaries so a
+        // function/class is not split mid-body, and prepend file/type context to
+        // each chunk to ground the embedding (story #249). Falls back to size-based
+        // chunking when the language has no parser or yields no boundaries.
+        if (filePath is not null &&
+            StructuralLanguagesByExtension.TryGetValue(Path.GetExtension(filePath), out var lang))
+        {
+            var boundaries = _analysis.GetStructuralBoundaries(content, lang);
+            if (boundaries.Count > 0)
+                return ChunkStructured(content, filePath, boundaries, opts);
+        }
+
+        return ChunkBySize(content, filePath, opts);
+    }
+
+    private static List<CodeChunk> ChunkBySize(string content, string? filePath, ChunkingOptions opts)
+    {
         var lines = SplitLines(content);
         var chunks = new List<CodeChunk>();
 
@@ -224,4 +260,127 @@ public class ChunkingService : IChunkingService
     }
 
     private record OverlapResult(string Text, int RuneCount, int LineCount);
+
+    // ----- Structure-aware chunking (story #249) -----
+
+    private static List<CodeChunk> ChunkStructured(
+        string content, string filePath, IReadOnlyList<StructuralBoundary> boundaries, ChunkingOptions opts)
+    {
+        var lines = SplitLines(content);
+        var lineByteOffsets = ComputeLineByteOffsets(lines);
+        var segments = BuildSegments(lines.Count, boundaries);
+
+        var chunks = new List<CodeChunk>();
+        var buf = new StringBuilder();
+        int bufStart = 0, bufEnd = 0, bufRunes = 0;
+        var bufContext = "";
+
+        void Flush()
+        {
+            if (bufRunes == 0) return;
+            chunks.Add(MakeStructuredChunk(buf.ToString(), filePath, bufContext, bufStart, bufEnd, lineByteOffsets));
+            buf.Clear();
+            bufRunes = 0;
+        }
+
+        foreach (var (start, end, context) in segments)
+        {
+            var text = JoinLines(lines, start, end);
+            if (string.IsNullOrWhiteSpace(text)) continue;
+            var runes = CountRunes(text);
+
+            // A single declaration larger than the size limit is flushed on its own
+            // and then size-split, so we never merge a giant body with its neighbors.
+            if (runes > opts.Size)
+            {
+                Flush();
+                foreach (var sub in ChunkBySize(text, filePath, opts))
+                {
+                    chunks.Add(MakeStructuredChunk(
+                        sub.Content, filePath, context,
+                        start + sub.StartLine - 1, start + sub.EndLine - 1, lineByteOffsets));
+                }
+                continue;
+            }
+
+            // Adding this declaration would overflow the current chunk: start a new one.
+            if (bufRunes > 0 && bufRunes + runes > opts.Size)
+                Flush();
+
+            if (bufRunes == 0)
+            {
+                bufStart = start;
+                bufContext = context;
+            }
+            else if (bufContext.Length == 0 && context.Length > 0)
+            {
+                // A leading file-level segment merged with a declaration: adopt the
+                // declaration's context for the chunk header.
+                bufContext = context;
+            }
+            buf.Append(text);
+            bufRunes += runes;
+            bufEnd = end;
+        }
+
+        Flush();
+        return chunks;
+    }
+
+    // Partition lines [1..lineCount] at the boundary lines into contiguous segments.
+    // Lines before the first boundary become a leading file-context segment.
+    private static List<(int Start, int End, string Context)> BuildSegments(
+        int lineCount, IReadOnlyList<StructuralBoundary> boundaries)
+    {
+        var segments = new List<(int, int, string)>();
+        var first = Math.Clamp(boundaries[0].Line, 1, lineCount + 1);
+        if (first > 1)
+            segments.Add((1, first - 1, ""));
+
+        for (var i = 0; i < boundaries.Count; i++)
+        {
+            var start = Math.Clamp(boundaries[i].Line, 1, lineCount);
+            var end = i + 1 < boundaries.Count
+                ? Math.Clamp(boundaries[i + 1].Line - 1, start, lineCount)
+                : lineCount;
+            if (end >= start)
+                segments.Add((start, end, boundaries[i].Context));
+        }
+        return segments;
+    }
+
+    private static CodeChunk MakeStructuredChunk(
+        string body, string filePath, string context, int startLine, int endLine, int[] lineByteOffsets)
+    {
+        var header = context.Length > 0 ? $"// {filePath} — {context}\n" : $"// {filePath}\n";
+        var offset = startLine >= 1 && startLine <= lineByteOffsets.Length ? lineByteOffsets[startLine - 1] : 0;
+        return new CodeChunk
+        {
+            Content = header + body,
+            StartLine = startLine,
+            EndLine = endLine,
+            FilePath = filePath,
+            ByteOffset = offset
+        };
+    }
+
+    private static string JoinLines(List<string> lines, int start, int end)
+    {
+        var sb = new StringBuilder();
+        for (var i = start; i <= end && i <= lines.Count; i++)
+            sb.Append(lines[i - 1]);
+        return sb.ToString();
+    }
+
+    private static int[] ComputeLineByteOffsets(List<string> lines)
+    {
+        var offsets = new int[lines.Count];
+        var running = 0;
+        for (var i = 0; i < lines.Count; i++)
+        {
+            offsets[i] = running;
+            running += Encoding.UTF8.GetByteCount(lines[i]);
+        }
+        return offsets;
+    }
 }

--- a/src/Andy.CodeIndex.Infrastructure/Services/CodeAnalysisService.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Services/CodeAnalysisService.cs
@@ -18,6 +18,99 @@ public class CodeAnalysisService : ICodeAnalysisService
 
     public bool SupportsLanguage(string language) => SupportedLanguages.Contains(language);
 
+    public IReadOnlyList<StructuralBoundary> GetStructuralBoundaries(string content, string language) =>
+        language.ToLowerInvariant() switch
+        {
+            "csharp" => CSharpBoundaries(content),
+            "javascript" => JavaScriptBoundaries(content),
+            _ => []
+        };
+
+    private static List<StructuralBoundary> CSharpBoundaries(string content)
+    {
+        var root = CSharpSyntaxTree.ParseText(content).GetRoot();
+        var list = new List<StructuralBoundary>();
+
+        foreach (var node in root.DescendantNodes())
+        {
+            switch (node)
+            {
+                case BaseTypeDeclarationSyntax t:
+                    list.Add(new StructuralBoundary(StartLine(t), TypeContext(t)));
+                    break;
+                case MethodDeclarationSyntax m:
+                    list.Add(new StructuralBoundary(StartLine(m), MemberContext(m, m.Identifier.Text)));
+                    break;
+                case ConstructorDeclarationSyntax c:
+                    list.Add(new StructuralBoundary(StartLine(c), MemberContext(c, c.Identifier.Text)));
+                    break;
+            }
+        }
+        return NormalizeBoundaries(list);
+
+        static int StartLine(SyntaxNode n) => n.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+        static string TypeContext(BaseTypeDeclarationSyntax t)
+        {
+            var ns = t.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().FirstOrDefault()?.Name.ToString();
+            return ns is null ? t.Identifier.Text : $"{ns}.{t.Identifier.Text}";
+        }
+
+        static string MemberContext(SyntaxNode member, string name)
+        {
+            var type = member.Ancestors().OfType<BaseTypeDeclarationSyntax>().FirstOrDefault()?.Identifier.Text;
+            return type is null ? name : $"{type}.{name}";
+        }
+    }
+
+    private static List<StructuralBoundary> JavaScriptBoundaries(string content)
+    {
+        Module program;
+        try { program = new Parser().ParseModule(content); }
+        catch (Exception) { return []; }
+
+        var list = new List<StructuralBoundary>();
+        foreach (var stmt in program.Body)
+        {
+            var decl = stmt switch
+            {
+                ExportNamedDeclaration { Declaration: { } d } => d,
+                ExportDefaultDeclaration def => def.Declaration,
+                _ => (Node)stmt
+            };
+
+            switch (decl)
+            {
+                case ClassDeclaration cls:
+                    var name = cls.Id?.Name ?? "default";
+                    list.Add(new StructuralBoundary(cls.Location.Start.Line, name));
+                    foreach (var member in cls.Body.Body)
+                        if (member is MethodDefinition { Key: Identifier key } md)
+                            list.Add(new StructuralBoundary(md.Location.Start.Line, $"{name}.{key.Name}"));
+                    break;
+                case FunctionDeclaration fn:
+                    list.Add(new StructuralBoundary(fn.Location.Start.Line, fn.Id?.Name ?? "default"));
+                    break;
+                case VariableDeclaration vd:
+                    foreach (var v in vd.Declarations)
+                        if (v.Init is IFunction && v.Id is Identifier id)
+                            list.Add(new StructuralBoundary(v.Location.Start.Line, id.Name));
+                    break;
+            }
+        }
+        return NormalizeBoundaries(list);
+    }
+
+    // Sort by line, drop duplicates and any non-positive lines.
+    private static List<StructuralBoundary> NormalizeBoundaries(List<StructuralBoundary> list)
+    {
+        var seen = new HashSet<int>();
+        return list
+            .Where(b => b.Line > 0 && seen.Add(b.Line))
+            .OrderBy(b => b.Line)
+            .ToList();
+    }
+
     public CodeAnalysisResult Analyze(string content, string filePath, string language)
     {
         var result = new CodeAnalysisResult { FilePath = filePath, Language = language };

--- a/tests/Andy.CodeIndex.Tests.Unit/Services/StructuralChunkingTests.cs
+++ b/tests/Andy.CodeIndex.Tests.Unit/Services/StructuralChunkingTests.cs
@@ -1,0 +1,100 @@
+using Andy.CodeIndex.Application.Options;
+using Andy.CodeIndex.Infrastructure.Services;
+using FluentAssertions;
+
+namespace Andy.CodeIndex.Tests.Unit.Services;
+
+/// <summary>
+/// Structure-aware chunking (story #249): chunks align to declaration boundaries
+/// (Roslyn for C#, Acornima for JS) instead of arbitrary size cuts, and each
+/// chunk carries a "// file — Context" header to ground the embedding. Falls back
+/// to size-based chunking for unparsed languages.
+/// </summary>
+public class StructuralChunkingTests
+{
+    private readonly ChunkingService _service = new();
+
+    [Fact]
+    public void CSharp_SplitsAtMethodBoundaries_WithContextHeader()
+    {
+        var code = @"namespace Demo
+{
+    public class Service
+    {
+        public int Add(int a, int b) { return a + b; }
+        public int Subtract(int a, int b) { return a - b; }
+        public int Multiply(int a, int b) { return a * b; }
+    }
+}
+";
+        // Small size forces one chunk per method rather than one merged chunk.
+        var options = new ChunkingOptions { Size = 80, Overlap = 0, MinSize = 1 };
+        var result = _service.ChunkText(code, "Service.cs", options);
+
+        result.Should().HaveCountGreaterThan(2);
+        result.Should().OnlyContain(c => c.Content.StartsWith("// Service.cs"));
+
+        // The chunk that begins at the Add method (line 5) is grounded with its context.
+        var addChunk = result.Should().ContainSingle(c => c.StartLine == 5).Subject;
+        addChunk.Content.Should().Contain("Service.Add");
+        addChunk.Content.Should().Contain("a + b");
+
+        // A method is not split across chunks: the Subtract body stays whole.
+        result.Should().ContainSingle(c => c.Content.Contains("a - b"))
+            .Which.Content.Should().Contain("Service.Subtract");
+    }
+
+    [Fact]
+    public void CSharp_SmallFile_FitsInOneChunk_StillHasHeader()
+    {
+        var code = "namespace N { public class A { public void M() { } } }\n";
+        var result = _service.ChunkText(code, "A.cs");
+
+        result.Should().ContainSingle();
+        result[0].Content.Should().StartWith("// A.cs");
+        result[0].Content.Should().Contain("public class A");
+    }
+
+    [Fact]
+    public void JavaScript_SplitsClassMethodsAndArrowExports()
+    {
+        var code = @"export class Calc {
+  add(a, b) { return a + b; }
+  subtract(a, b) { return a - b; }
+}
+export const helper = (x) => x * 2;
+";
+        var options = new ChunkingOptions { Size = 40, Overlap = 0, MinSize = 1 };
+        var result = _service.ChunkText(code, "calc.js", options);
+
+        result.Should().OnlyContain(c => c.Content.StartsWith("// calc.js"));
+        result.Should().Contain(c => c.Content.Contains("Calc.add") && c.Content.Contains("a + b"));
+        result.Should().Contain(c => c.Content.Contains("a - b"));
+    }
+
+    [Fact]
+    public void UnparsedLanguage_FallsBackToSizeBased_NoHeader()
+    {
+        // No structural parser for .txt → size-based path, content unchanged.
+        var code = "just some plain text\nwith a couple of lines\n";
+        var options = new ChunkingOptions { Size = 1500, Overlap = 0, MinSize = 1 };
+        var result = _service.ChunkText(code, "notes.txt", options);
+
+        result.Should().ContainSingle();
+        result[0].Content.Should().NotStartWith("//");
+        result[0].Content.Should().Be(code);
+    }
+
+    [Fact]
+    public void NonStructuralCSharpContent_FallsBackGracefully()
+    {
+        // A .cs path whose content has no type/method declarations yields no
+        // boundaries, so the chunker falls back to size-based without throwing.
+        var code = "// just a comment\nint x = 1;\n";
+        var options = new ChunkingOptions { Size = 1500, Overlap = 0, MinSize = 1 };
+        var act = () => _service.ChunkText(code, "loose.cs", options);
+
+        act.Should().NotThrow();
+        act().Should().NotBeEmpty();
+    }
+}


### PR DESCRIPTION
Third story of **epic #243**. The chunker split purely by rune count — cutting functions mid-body and stripping the enclosing context embedding models need (the primary failure mode for code retrieval per cAST, CMU 2025). It now aligns chunks to declaration boundaries and grounds each with a context header.

## How
- **`ICodeAnalysisService.GetStructuralBoundaries(content, language)`** returns the 1-based start line + context label of each top-level type/method/function — **Roslyn for C#**, **Acornima for JS**, empty otherwise.
- **`ChunkingService`** infers language from the file extension and, when boundaries exist, partitions the file at them:
  - small adjacent declarations merge up to the size limit,
  - an oversized single declaration is flushed and size-split on its own (never merged with neighbors),
  - each chunk is prefixed with `// <file> — <Context>` to ground the embedding,
  - `StartLine`/`EndLine` now track real declaration spans.
- **Falls back** to the existing size-based chunker for unparsed languages / declaration-less files — behavior unchanged there.

## Compatibility
- `IChunkingService` signature is **untouched** → handlers and mocks need no changes.
- The new analyzer dependency is optional (`ChunkingService(ICodeAnalysisService? = null)`); DI supplies it, `new ChunkingService()` still works.

## Testing
- Full solution builds clean (0 warnings).
- Unit **789 passed** (+5 in `StructuralChunkingTests`; existing 12 `ChunkingServiceTests` still green).
- Integration **102 passed** (the real indexing pipeline exercises structural chunking via DI). The only failures remain the pre-existing git-backed unit tests and the pre-existing `ChatApiTests` dimension test — all fail on `main`.

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)