### PR TITLE
Golden-file fixtures for language API extraction (story #250)

### DIFF
--- a/tests/Andy.CodeIndex.Tests.Unit/Andy.CodeIndex.Tests.Unit.csproj
+++ b/tests/Andy.CodeIndex.Tests.Unit/Andy.CodeIndex.Tests.Unit.csproj
@@ -31,6 +31,11 @@
     <None Include="..\..\src\Andy.CodeIndex.Api\Data\question-ontology.json" Link="Data\question-ontology.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <!-- Sample sources are test data, not part of the test assembly. -->
+    <Compile Remove="Fixtures\**\*.cs" />
+    <Content Include="Fixtures\CodeSamples\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Andy.CodeIndex.Tests.Unit/Fixtures/CodeSamples/Sample.cs
+++ b/tests/Andy.CodeIndex.Tests.Unit/Fixtures/CodeSamples/Sample.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Acme.Billing;
+
+/// <summary>A monetary amount in a currency.</summary>
+public record Money(decimal Amount, string Currency);
+
+public interface IInvoiceService
+{
+    Task<Money> GetTotalAsync(Guid invoiceId);
+    int Count { get; }
+}
+
+/// <summary>Issues and totals invoices.</summary>
+public class InvoiceService : ServiceBase, IInvoiceService
+{
+    public required string Region { get; set; }
+    private int _issued;
+
+    public InvoiceService(string region) => Region = region;
+
+    /// <summary>Returns the invoice total.</summary>
+    public async Task<Money> GetTotalAsync(Guid invoiceId)
+    {
+        await Task.Delay(1);
+        return new Money(0m, "USD");
+    }
+
+    public int Count => _issued;
+
+    public static InvoiceService CreateDefault() => new("US");
+
+    private void Touch() => _issued++;
+
+    public class LineItem
+    {
+        public string Sku { get; set; } = "";
+        public decimal Price { get; set; }
+    }
+}
+
+public enum InvoiceStatus
+{
+    Draft,
+    Issued,
+    Paid
+}

--- a/tests/Andy.CodeIndex.Tests.Unit/Fixtures/CodeSamples/Sample.java
+++ b/tests/Andy.CodeIndex.Tests.Unit/Fixtures/CodeSamples/Sample.java
@@ -1,0 +1,23 @@
+package com.acme.billing;
+
+public interface InvoiceService {
+    Money getTotal(String invoiceId);
+}
+
+public class HttpInvoiceService extends ServiceBase implements InvoiceService {
+    private final String region;
+
+    public HttpInvoiceService(String region) {
+        this.region = region;
+    }
+
+    public Money getTotal(String invoiceId) {
+        return new Money(0, "USD");
+    }
+}
+
+public enum InvoiceStatus {
+    DRAFT,
+    ISSUED,
+    PAID
+}

--- a/tests/Andy.CodeIndex.Tests.Unit/Fixtures/CodeSamples/sample.go
+++ b/tests/Andy.CodeIndex.Tests.Unit/Fixtures/CodeSamples/sample.go
@@ -1,0 +1,27 @@
+package billing
+
+import "context"
+
+// Invoice is a billing document.
+type Invoice struct {
+	ID     string
+	Amount int64
+}
+
+// Repository reads and writes invoices.
+type Repository interface {
+	Get(ctx context.Context, id string) (*Invoice, error)
+	Save(ctx context.Context, inv *Invoice) error
+}
+
+// NewInvoice constructs an Invoice.
+func NewInvoice(id string, amount int64) *Invoice {
+	return &Invoice{ID: id, Amount: amount}
+}
+
+// Total returns the amount.
+func Total(inv *Invoice) int64 {
+	return inv.Amount
+}
+
+func unexportedHelper() {}

--- a/tests/Andy.CodeIndex.Tests.Unit/Fixtures/CodeSamples/sample.js
+++ b/tests/Andy.CodeIndex.Tests.Unit/Fixtures/CodeSamples/sample.js
@@ -1,0 +1,29 @@
+export class Widget extends Base {
+  constructor(id) {
+    this.id = id;
+  }
+
+  async render(target) {
+    return target;
+  }
+
+  static create(id) {
+    return new Widget(id);
+  }
+}
+
+export function build(a, b) {
+  return a + b;
+}
+
+export const scale = (value, factor = 2) => value * factor;
+
+export const fetchData = async (url) => {
+  return await fetch(url);
+};
+
+function internalHelper(x) {
+  return x;
+}
+
+export default class App {}

--- a/tests/Andy.CodeIndex.Tests.Unit/Fixtures/CodeSamples/sample.py
+++ b/tests/Andy.CodeIndex.Tests.Unit/Fixtures/CodeSamples/sample.py
@@ -1,0 +1,36 @@
+"""Sample module for golden-file analysis tests."""
+import asyncio
+
+
+class Repository:
+    """Stores widgets."""
+
+    def __init__(self, name):
+        self.name = name
+
+    async def fetch(self, widget_id, timeout=30) -> dict:
+        await asyncio.sleep(0)
+        return {}
+
+    @property
+    def label(self) -> str:
+        return self.name
+
+    @staticmethod
+    def default() -> "Repository":
+        return Repository("default")
+
+    def _internal(self):
+        pass
+
+
+def build_repository(name: str) -> Repository:
+    return Repository(name)
+
+
+async def load_all(source):
+    return []
+
+
+def _private_helper():
+    pass

--- a/tests/Andy.CodeIndex.Tests.Unit/Fixtures/CodeSamples/sample.ts
+++ b/tests/Andy.CodeIndex.Tests.Unit/Fixtures/CodeSamples/sample.ts
@@ -1,0 +1,26 @@
+export interface UserService {
+  getUser(id: number): Promise<User>;
+  readonly count: number;
+}
+
+export class HttpUserService implements UserService {
+  getUser(id: number): Promise<User> {
+    return Promise.resolve(new User());
+  }
+}
+
+export function createService(): UserService {
+  return new HttpUserService();
+}
+
+export const makeHandler = (route: string) => (req: Request): Response => handle(route, req);
+
+export const loadAsync = async (id: number): Promise<User> => fetchUser(id);
+
+export enum Role {
+  Admin,
+  Editor,
+  Viewer,
+}
+
+export default function bootstrap(): void {}

--- a/tests/Andy.CodeIndex.Tests.Unit/Services/CodeAnalysisGoldenFixtureTests.cs
+++ b/tests/Andy.CodeIndex.Tests.Unit/Services/CodeAnalysisGoldenFixtureTests.cs
@@ -1,0 +1,120 @@
+using Andy.CodeIndex.Application.Interfaces;
+using Andy.CodeIndex.Infrastructure.Services;
+using FluentAssertions;
+
+namespace Andy.CodeIndex.Tests.Unit.Services;
+
+/// <summary>
+/// Golden-file coverage (story #250): runs the analyzer over real source files
+/// for every supported language and asserts the extracted API. This is the only
+/// parsing coverage for Go and Java, and exercises the C#/Python/JS/TS analyzers
+/// against whole files rather than inline snippets.
+/// </summary>
+public class CodeAnalysisGoldenFixtureTests
+{
+    private readonly CodeAnalysisService _service = new();
+
+    private static string Load(string fileName)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", "CodeSamples", fileName);
+        return File.ReadAllText(path);
+    }
+
+    private CodeAnalysisResult Analyze(string fileName, string language) =>
+        _service.Analyze(Load(fileName), fileName, language);
+
+    [Fact]
+    public void CSharp_Fixture_ExtractsRecordsInterfacesClassesEnumsAndDocs()
+    {
+        var r = Analyze("Sample.cs", "csharp");
+
+        r.Classes.Select(c => c.Name).Should().Contain(new[] { "Money", "InvoiceService", "LineItem" });
+        r.Interfaces.Select(i => i.Name).Should().Contain("IInvoiceService");
+        r.Enums.Should().ContainSingle(e => e.Name == "InvoiceStatus")
+            .Which.Values.Should().Equal("Draft", "Issued", "Paid");
+
+        var svc = r.Classes.Single(c => c.Name == "InvoiceService");
+        svc.Summary.Should().Be("Issues and totals invoices.");
+        svc.ImplementedInterfaces.Should().Contain("IInvoiceService");
+        svc.BaseClass.Should().Be("ServiceBase");
+        svc.Methods.Should().Contain(m => m.Name == "GetTotalAsync" && m.IsAsync);
+        svc.Methods.Should().Contain(m => m.Name == "CreateDefault" && m.IsStatic);
+        svc.Methods.Should().NotContain(m => m.Name == "Touch"); // private excluded
+
+        // Nested type's members attributed to it, not the outer class.
+        r.Classes.Single(c => c.Name == "LineItem").Properties.Select(p => p.Name)
+            .Should().Contain(new[] { "Sku", "Price" });
+
+        // Interface members populated, and the record's positional params surface.
+        r.Interfaces.Single().Methods.Should().Contain(m => m.Name == "GetTotalAsync");
+        r.Classes.Single(c => c.Name == "Money").Properties.Select(p => p.Name)
+            .Should().Equal("Amount", "Currency");
+    }
+
+    [Fact]
+    public void Python_Fixture_ExtractsMethodsAsyncDecoratorsAndModuleFunctions()
+    {
+        var r = Analyze("sample.py", "python");
+
+        var repo = r.Classes.Should().ContainSingle(c => c.Name == "Repository").Subject;
+        repo.Methods.Select(m => m.Name).Should().Contain(new[] { "__init__", "fetch", "default" });
+        repo.Methods.Should().NotContain(m => m.Name == "_internal");
+        repo.Methods.Single(m => m.Name == "fetch").IsAsync.Should().BeTrue();
+        repo.Methods.Single(m => m.Name == "default").IsStatic.Should().BeTrue();
+        repo.Properties.Should().ContainSingle(p => p.Name == "label");
+
+        r.Functions.Select(f => f.Name).Should().Contain(new[] { "build_repository", "load_all" });
+        r.Functions.Select(f => f.Name).Should().NotContain("_private_helper");
+        r.Functions.Single(f => f.Name == "load_all").IsAsync.Should().BeTrue();
+    }
+
+    [Fact]
+    public void JavaScript_Fixture_ExtractsClassMethodsArrowsAndDefaults()
+    {
+        var r = Analyze("sample.js", "javascript");
+
+        var widget = r.Classes.Should().ContainSingle(c => c.Name == "Widget").Subject;
+        widget.BaseClass.Should().Be("Base");
+        widget.Methods.Single(m => m.Name == "render").IsAsync.Should().BeTrue();
+        widget.Methods.Single(m => m.Name == "create").IsStatic.Should().BeTrue();
+
+        r.Classes.Select(c => c.Name).Should().Contain("App"); // export default class
+        r.Functions.Select(f => f.Name).Should().Contain(new[] { "build", "scale", "fetchData" });
+        r.Functions.Single(f => f.Name == "fetchData").IsAsync.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TypeScript_Fixture_ExtractsExportedItemsIncludingArrowsAndDefault()
+    {
+        var r = Analyze("sample.ts", "typescript");
+
+        r.Classes.Select(c => c.Name).Should().Contain("HttpUserService");
+        r.Interfaces.Select(i => i.Name).Should().Contain("UserService");
+        r.Enums.Should().ContainSingle(e => e.Name == "Role")
+            .Which.Values.Should().Equal("Admin", "Editor", "Viewer");
+        r.Functions.Select(f => f.Name).Should().Contain(
+            new[] { "createService", "makeHandler", "loadAsync", "bootstrap" });
+    }
+
+    [Fact]
+    public void Go_Fixture_ExtractsStructsInterfacesAndExportedFunctions()
+    {
+        var r = Analyze("sample.go", "go");
+
+        r.Classes.Select(c => c.Name).Should().Contain("Invoice");
+        r.Interfaces.Select(i => i.Name).Should().Contain("Repository");
+        r.Functions.Select(f => f.Name).Should().Contain(new[] { "NewInvoice", "Total" });
+        r.Functions.Select(f => f.Name).Should().NotContain("unexportedHelper");
+    }
+
+    [Fact]
+    public void Java_Fixture_ExtractsClassesInterfacesAndEnums()
+    {
+        var r = Analyze("Sample.java", "java");
+
+        r.Classes.Select(c => c.Name).Should().Contain("HttpInvoiceService");
+        r.Interfaces.Select(i => i.Name).Should().Contain("InvoiceService");
+        r.Enums.Should().ContainSingle(e => e.Name == "InvoiceStatus")
+            .Which.Values.Should().Equal("DRAFT", "ISSUED", "PAID");
+    }
+}


### PR DESCRIPTION
Final story of **epic #243**. Adds real source fixtures + a golden test that runs the analyzer over whole files and asserts the extracted API per language.

- **Fixtures** under `Fixtures/CodeSamples`: `Sample.cs`, `sample.py`, `sample.js`, `sample.ts`, `sample.go`, `Sample.java`.
- **First parsing coverage for Go and Java** (previously zero tests).
- Exercises the C#/Python/JS/TS analyzers against complete files (records, nested types, async, decorators, arrow/default exports, XML-doc summaries) rather than inline snippets.
- Fixtures are copied to output and excluded from compilation (`Compile Remove`) so the sample sources are data, not part of the test assembly.

## Testing
- 6 golden tests pass; full unit suite **795 passed** (+6). Only the 4 pre-existing git-backed failures remain (also fail on `main`).

Closes #250 — completes epic #243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)