### PR TITLE
Fix C#/Python/JS dependency parsing (stories #255-257)

### DIFF
--- a/src/Andy.CodeIndex.Infrastructure/Parsers/DependencyParserService.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Parsers/DependencyParserService.cs
@@ -9,7 +9,7 @@ public class DependencyParserService : IDependencyParserService
     private static readonly string[] DependencyFileNames =
     [
         ".csproj", "Directory.Build.props", "Directory.Packages.props", "packages.config",
-        "package.json", "requirements.txt", "Pipfile", "pyproject.toml", "setup.py",
+        "package.json", "package-lock.json", "requirements.txt", "Pipfile", "pyproject.toml", "setup.py",
         "go.mod", "pom.xml", "build.gradle", "build.gradle.kts",
         "Cargo.toml", "Gemfile", "composer.json"
     ];
@@ -34,6 +34,9 @@ public class DependencyParserService : IDependencyParserService
         if (name.Equals("packages.config", StringComparison.OrdinalIgnoreCase))
             return ParsePackagesConfig(content, fileName);
 
+        if (name.Equals("package-lock.json", StringComparison.OrdinalIgnoreCase))
+            return ParsePackageLockJson(content, fileName);
+
         if (name.Equals("package.json", StringComparison.OrdinalIgnoreCase))
             return ParsePackageJson(content, fileName);
 
@@ -42,6 +45,12 @@ public class DependencyParserService : IDependencyParserService
 
         if (name.Equals("pyproject.toml", StringComparison.OrdinalIgnoreCase))
             return ParsePyprojectToml(content, fileName);
+
+        if (name.Equals("setup.py", StringComparison.OrdinalIgnoreCase))
+            return ParseSetupPy(content, fileName);
+
+        if (name.Equals("Pipfile", StringComparison.OrdinalIgnoreCase))
+            return ParsePipfile(content, fileName);
 
         if (name.Equals("go.mod", StringComparison.OrdinalIgnoreCase))
             return ParseGoMod(content, fileName);
@@ -68,18 +77,52 @@ public class DependencyParserService : IDependencyParserService
     internal static List<PackageDependency> ParseCsproj(string content, string file)
     {
         var deps = new List<PackageDependency>();
+
+        // <PackageReference Include="X" Version="Y" />, self-closing or with a body
+        // that may carry a child <Version>Y</Version> element (story #255).
         foreach (Match m in Regex.Matches(content,
-            @"<PackageReference\s+Include=""([^""]+)""(?:\s+Version=""([^""]+)"")?", RegexOptions.IgnoreCase))
+            @"<PackageReference\s+Include=""([^""]+)""([^>]*?)(?:/>|>(.*?)</PackageReference>)",
+            RegexOptions.IgnoreCase | RegexOptions.Singleline))
         {
+            var version = VersionFromAttributes(m.Groups[2].Value)
+                ?? (m.Groups[3].Success ? VersionFromChildElement(m.Groups[3].Value) : null);
             deps.Add(new PackageDependency
             {
                 Name = m.Groups[1].Value,
-                Version = m.Groups[2].Success ? m.Groups[2].Value : null,
+                Version = version,
                 Source = "nuget",
                 SourceFile = file
             });
         }
+
+        // Central Package Management: versions live in Directory.Packages.props as
+        // <PackageVersion Include="X" Version="Y" />. Without this, CPM repos report
+        // null versions for every package (story #255).
+        foreach (Match m in Regex.Matches(content,
+            @"<PackageVersion\s+Include=""([^""]+)""([^>]*?)/?>", RegexOptions.IgnoreCase))
+        {
+            deps.Add(new PackageDependency
+            {
+                Name = m.Groups[1].Value,
+                Version = VersionFromAttributes(m.Groups[2].Value),
+                Source = "nuget",
+                SourceFile = file
+            });
+        }
+
         return deps;
+    }
+
+    private static string? VersionFromAttributes(string attributes)
+    {
+        var m = Regex.Match(attributes, @"Version=""([^""]+)""", RegexOptions.IgnoreCase);
+        return m.Success ? m.Groups[1].Value : null;
+    }
+
+    private static string? VersionFromChildElement(string inner)
+    {
+        var m = Regex.Match(inner, @"<Version>\s*([^<]+?)\s*</Version>", RegexOptions.IgnoreCase);
+        return m.Success ? m.Groups[1].Value : null;
     }
 
     internal static List<PackageDependency> ParsePackagesConfig(string content, string file)
@@ -108,13 +151,57 @@ public class DependencyParserService : IDependencyParserService
             using var doc = JsonDocument.Parse(content);
             var root = doc.RootElement;
 
-            if (root.TryGetProperty("dependencies", out var runtime))
-                foreach (var prop in runtime.EnumerateObject())
-                    deps.Add(new PackageDependency { Name = prop.Name, Version = prop.Value.GetString(), Scope = "runtime", Source = "npm", SourceFile = file });
+            // Scope per dependency map. peer/optional were previously ignored (story #257).
+            AddNpmScope(root, "dependencies", "runtime", deps, file);
+            AddNpmScope(root, "devDependencies", "dev", deps, file);
+            AddNpmScope(root, "peerDependencies", "peer", deps, file);
+            AddNpmScope(root, "optionalDependencies", "optional", deps, file);
+        }
+        catch { }
+        return deps;
+    }
 
-            if (root.TryGetProperty("devDependencies", out var dev))
-                foreach (var prop in dev.EnumerateObject())
-                    deps.Add(new PackageDependency { Name = prop.Name, Version = prop.Value.GetString(), Scope = "dev", Source = "npm", SourceFile = file });
+    private static void AddNpmScope(JsonElement root, string property, string scope, List<PackageDependency> deps, string file)
+    {
+        if (root.TryGetProperty(property, out var map) && map.ValueKind == JsonValueKind.Object)
+            foreach (var prop in map.EnumerateObject())
+                deps.Add(new PackageDependency { Name = prop.Name, Version = prop.Value.GetString(), Scope = scope, Source = "npm", SourceFile = file });
+    }
+
+    // Resolved versions from package-lock.json (lockfileVersion 2/3 "packages" map,
+    // or v1 "dependencies" map). Captures direct top-level packages (story #257).
+    internal static List<PackageDependency> ParsePackageLockJson(string content, string file)
+    {
+        var deps = new List<PackageDependency>();
+        try
+        {
+            using var doc = JsonDocument.Parse(content);
+            var root = doc.RootElement;
+
+            if (root.TryGetProperty("packages", out var packages) && packages.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var prop in packages.EnumerateObject())
+                {
+                    // Keys look like "node_modules/<name>" (direct) or deeper (transitive).
+                    // Capture direct entries: a single node_modules segment, optional @scope.
+                    var key = prop.Name;
+                    if (!key.StartsWith("node_modules/", StringComparison.Ordinal)) continue;
+                    var name = key["node_modules/".Length..];
+                    if (name.Contains("/node_modules/", StringComparison.Ordinal)) continue; // transitive
+                    var version = prop.Value.TryGetProperty("version", out var v) ? v.GetString() : null;
+                    var scope = prop.Value.TryGetProperty("dev", out var dev) && dev.ValueKind == JsonValueKind.True ? "dev" : "runtime";
+                    deps.Add(new PackageDependency { Name = name, Version = version, Scope = scope, Source = "npm", SourceFile = file });
+                }
+            }
+            else if (root.TryGetProperty("dependencies", out var v1) && v1.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var prop in v1.EnumerateObject())
+                {
+                    var version = prop.Value.TryGetProperty("version", out var v) ? v.GetString() : null;
+                    var scope = prop.Value.TryGetProperty("dev", out var dev) && dev.ValueKind == JsonValueKind.True ? "dev" : "runtime";
+                    deps.Add(new PackageDependency { Name = prop.Name, Version = version, Scope = scope, Source = "npm", SourceFile = file });
+                }
+            }
         }
         catch { }
         return deps;
@@ -127,15 +214,34 @@ public class DependencyParserService : IDependencyParserService
         foreach (var line in content.Split('\n'))
         {
             var trimmed = line.Trim();
+            // Skip blanks, comments, and option lines (-r, -c, -e, --hash, ...).
             if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith('#') || trimmed.StartsWith('-')) continue;
 
-            var match = Regex.Match(trimmed, @"^([a-zA-Z0-9_.-]+)\s*([><=!~]+\s*.+)?$");
+            // Strip inline comment and environment marker (`pkg==1 ; python_version<'3.8'`).
+            var hash = trimmed.IndexOf(" #", StringComparison.Ordinal);
+            if (hash >= 0) trimmed = trimmed[..hash].Trim();
+            var semi = trimmed.IndexOf(';');
+            if (semi >= 0) trimmed = trimmed[..semi].Trim();
+            if (trimmed.Length == 0) continue;
+
+            // URL form: `name @ https://...` keeps the name, drops the URL as version.
+            var at = trimmed.IndexOf(" @ ", StringComparison.Ordinal);
+            if (at >= 0)
+            {
+                var urlName = StripExtras(trimmed[..at].Trim());
+                if (urlName.Length > 0)
+                    deps.Add(new PackageDependency { Name = urlName, Version = null, Source = "pypi", SourceFile = file });
+                continue;
+            }
+
+            // name[extra1,extra2]<version specifier>
+            var match = Regex.Match(trimmed, @"^([a-zA-Z0-9_.-]+)(\[[^\]]*\])?\s*([><=!~].*)?$");
             if (match.Success)
             {
                 deps.Add(new PackageDependency
                 {
                     Name = match.Groups[1].Value,
-                    Version = match.Groups[2].Success ? match.Groups[2].Value.Trim() : null,
+                    Version = match.Groups[3].Success ? match.Groups[3].Value.Trim() : null,
                     Source = "pypi",
                     SourceFile = file
                 });
@@ -144,25 +250,140 @@ public class DependencyParserService : IDependencyParserService
         return deps;
     }
 
+    private static string StripExtras(string name)
+    {
+        var bracket = name.IndexOf('[');
+        return bracket >= 0 ? name[..bracket] : name;
+    }
+
+    // Handles PEP 621 ([project] dependencies / optional-dependencies arrays) and
+    // Poetry ([tool.poetry.*dependencies] key = value tables) (story #256).
     internal static List<PackageDependency> ParsePyprojectToml(string content, string file)
     {
         var deps = new List<PackageDependency>();
-        var inDeps = false;
-        foreach (var line in content.Split('\n'))
+        var section = "";
+        var inPep621Array = false;
+
+        foreach (var raw in content.Split('\n'))
         {
-            var trimmed = line.Trim();
-            if (trimmed == "[project.dependencies]" || trimmed == "dependencies = [")
-                inDeps = true;
-            else if (trimmed.StartsWith('[') && inDeps)
-                inDeps = false;
-            else if (inDeps)
+            var line = raw.Trim();
+            if (line.Length == 0 || line.StartsWith('#')) continue;
+
+            if (line.StartsWith('[') && line.EndsWith(']'))
             {
-                var match = Regex.Match(trimmed, @"""?([a-zA-Z0-9_.-]+)(?:\s*([><=!~].+?))?""?,?$");
-                if (match.Success && match.Groups[1].Value.Length > 1)
-                    deps.Add(new PackageDependency { Name = match.Groups[1].Value, Version = match.Groups[2].Success ? match.Groups[2].Value : null, Source = "pypi", SourceFile = file });
+                section = line;
+                inPep621Array = false;
+                continue;
+            }
+
+            if (section == "[project]" && Regex.IsMatch(line, @"^dependencies\s*=\s*\["))
+            {
+                AddQuotedPyEntries(line, "runtime", deps, file);
+                inPep621Array = !line.Contains(']');
+                continue;
+            }
+            if (inPep621Array)
+            {
+                AddQuotedPyEntries(line, "runtime", deps, file);
+                if (line.Contains(']')) inPep621Array = false;
+                continue;
+            }
+
+            // [project.optional-dependencies] is a table of arrays: extra = ["pkg>=1"].
+            if (section == "[project.optional-dependencies]")
+            {
+                AddQuotedPyEntries(line, "optional", deps, file);
+                continue;
+            }
+
+            // Poetry tables: [tool.poetry.dependencies], .dev-dependencies, .group.X.dependencies
+            if (section.StartsWith("[tool.poetry") && section.EndsWith("dependencies]"))
+            {
+                var m = Regex.Match(line, @"^([A-Za-z0-9_.\-]+)\s*=\s*(.+)$");
+                if (m.Success && !m.Groups[1].Value.Equals("python", StringComparison.OrdinalIgnoreCase))
+                {
+                    var scope = section.Contains("dev") || section.Contains("group") ? "dev" : "runtime";
+                    deps.Add(new PackageDependency
+                    {
+                        Name = m.Groups[1].Value,
+                        Version = ExtractTomlVersion(m.Groups[2].Value),
+                        Scope = scope,
+                        Source = "pypi",
+                        SourceFile = file
+                    });
+                }
             }
         }
         return deps;
+    }
+
+    internal static List<PackageDependency> ParseSetupPy(string content, string file)
+    {
+        var deps = new List<PackageDependency>();
+        var m = Regex.Match(content, @"install_requires\s*=\s*\[(.*?)\]", RegexOptions.Singleline);
+        if (m.Success)
+            AddQuotedPyEntries(m.Groups[1].Value, "runtime", deps, file);
+        return deps;
+    }
+
+    internal static List<PackageDependency> ParsePipfile(string content, string file)
+    {
+        var deps = new List<PackageDependency>();
+        var section = "";
+        foreach (var raw in content.Split('\n'))
+        {
+            var line = raw.Trim();
+            if (line.Length == 0 || line.StartsWith('#')) continue;
+            if (line.StartsWith('[') && line.EndsWith(']')) { section = line; continue; }
+
+            if (section is "[packages]" or "[dev-packages]")
+            {
+                var m = Regex.Match(line, @"^([A-Za-z0-9_.\-]+)\s*=\s*(.+)$");
+                if (m.Success)
+                {
+                    var version = ExtractTomlVersion(m.Groups[2].Value);
+                    deps.Add(new PackageDependency
+                    {
+                        Name = m.Groups[1].Value,
+                        Version = version == "*" ? null : version,
+                        Scope = section == "[dev-packages]" ? "dev" : "runtime",
+                        Source = "pypi",
+                        SourceFile = file
+                    });
+                }
+            }
+        }
+        return deps;
+    }
+
+    // Extracts dependency specs from quoted strings in a line/block: "pkg[extra]>=1.0".
+    private static void AddQuotedPyEntries(string text, string scope, List<PackageDependency> deps, string file)
+    {
+        foreach (Match q in Regex.Matches(text, @"[""']([^""']+)[""']"))
+        {
+            var entry = q.Groups[1].Value.Trim();
+            var m = Regex.Match(entry, @"^([a-zA-Z0-9_.-]+)(\[[^\]]*\])?\s*([><=!~].*)?$");
+            if (m.Success && m.Groups[1].Value.Length > 1)
+            {
+                deps.Add(new PackageDependency
+                {
+                    Name = m.Groups[1].Value,
+                    Version = m.Groups[3].Success ? m.Groups[3].Value.Trim() : null,
+                    Scope = scope,
+                    Source = "pypi",
+                    SourceFile = file
+                });
+            }
+        }
+    }
+
+    // Poetry/Pipfile value can be a string ("^1.0") or an inline table ({ version = "^1.0", ... }).
+    private static string? ExtractTomlVersion(string value)
+    {
+        var table = Regex.Match(value, @"version\s*=\s*[""']([^""']+)[""']");
+        if (table.Success) return table.Groups[1].Value;
+        var str = Regex.Match(value, @"^[""']([^""']+)[""']");
+        return str.Success ? str.Groups[1].Value : null;
     }
 
     // --- Go ---

--- a/tests/Andy.CodeIndex.Tests.Unit/Parsers/DependencyParserNewFormatsTests.cs
+++ b/tests/Andy.CodeIndex.Tests.Unit/Parsers/DependencyParserNewFormatsTests.cs
@@ -1,0 +1,204 @@
+using Andy.CodeIndex.Infrastructure.Parsers;
+using FluentAssertions;
+
+namespace Andy.CodeIndex.Tests.Unit.Parsers;
+
+/// <summary>
+/// Coverage for the dependency-parsing fixes in epic #245: C# Central Package
+/// Management (#255), Python setup.py/Pipfile/markers/Poetry (#256), and JS
+/// peer/optional deps + package-lock resolution (#257).
+/// </summary>
+public class DependencyParserNewFormatsTests
+{
+    // ---------- #255 C# Central Package Management ----------
+
+    [Fact]
+    public void Csproj_ParsesPackageVersion_FromDirectoryPackagesProps()
+    {
+        var props = @"
+<Project>
+  <ItemGroup>
+    <PackageVersion Include=""Serilog"" Version=""3.1.1"" />
+    <PackageVersion Include=""xunit"" Version=""2.9.2"" />
+  </ItemGroup>
+</Project>";
+        var deps = DependencyParserService.ParseCsproj(props, "Directory.Packages.props");
+
+        deps.Should().HaveCount(2);
+        deps.Single(d => d.Name == "Serilog").Version.Should().Be("3.1.1");
+        deps.Should().OnlyContain(d => d.Source == "nuget");
+    }
+
+    [Fact]
+    public void Csproj_ParsesChildElementVersion()
+    {
+        var csproj = @"
+<Project>
+  <ItemGroup>
+    <PackageReference Include=""Newtonsoft.Json"">
+      <Version>13.0.3</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>";
+        var deps = DependencyParserService.ParseCsproj(csproj, "app.csproj");
+
+        deps.Should().ContainSingle();
+        deps[0].Name.Should().Be("Newtonsoft.Json");
+        deps[0].Version.Should().Be("13.0.3");
+    }
+
+    [Fact]
+    public void Csproj_CpmReference_WithoutInlineVersion_HasNullVersion()
+    {
+        // Under CPM the .csproj reference has no version; it comes from the props file.
+        var csproj = @"<Project><ItemGroup><PackageReference Include=""Serilog"" /></ItemGroup></Project>";
+        var deps = DependencyParserService.ParseCsproj(csproj, "app.csproj");
+
+        deps.Should().ContainSingle(d => d.Name == "Serilog" && d.Version == null);
+    }
+
+    // ---------- #257 JavaScript ----------
+
+    [Fact]
+    public void PackageJson_ParsesPeerAndOptionalDependencies()
+    {
+        var json = @"{
+            ""dependencies"": { ""express"": ""^4.18.0"" },
+            ""peerDependencies"": { ""react"": "">=18"" },
+            ""optionalDependencies"": { ""fsevents"": ""^2.3.0"" }
+        }";
+        var deps = DependencyParserService.ParsePackageJson(json, "package.json");
+
+        deps.Single(d => d.Name == "react").Scope.Should().Be("peer");
+        deps.Single(d => d.Name == "fsevents").Scope.Should().Be("optional");
+        deps.Single(d => d.Name == "express").Scope.Should().Be("runtime");
+    }
+
+    [Fact]
+    public void PackageLock_V3_ResolvesDirectVersions_SkipsTransitive()
+    {
+        var lockJson = @"{
+            ""lockfileVersion"": 3,
+            ""packages"": {
+                """": { ""name"": ""root"" },
+                ""node_modules/express"": { ""version"": ""4.18.2"" },
+                ""node_modules/jest"": { ""version"": ""29.7.0"", ""dev"": true },
+                ""node_modules/express/node_modules/cookie"": { ""version"": ""0.5.0"" }
+            }
+        }";
+        var deps = DependencyParserService.ParsePackageLockJson(lockJson, "package-lock.json");
+
+        deps.Select(d => d.Name).Should().BeEquivalentTo(new[] { "express", "jest" });
+        deps.Single(d => d.Name == "express").Version.Should().Be("4.18.2");
+        deps.Single(d => d.Name == "jest").Scope.Should().Be("dev");
+    }
+
+    // ---------- #256 Python ----------
+
+    [Fact]
+    public void Requirements_HandlesExtrasMarkersAndUrls()
+    {
+        var txt = @"
+requests[security]>=2.28.0
+django==4.2 ; python_version >= '3.8'
+mypkg @ https://example.com/mypkg.whl
+flask==2.3.0  # inline comment
+";
+        var deps = DependencyParserService.ParseRequirementsTxt(txt, "requirements.txt");
+
+        deps.Single(d => d.Name == "requests").Version.Should().Be(">=2.28.0");
+        deps.Single(d => d.Name == "django").Version.Should().Be("==4.2");
+        deps.Single(d => d.Name == "mypkg").Version.Should().BeNull();
+        deps.Single(d => d.Name == "flask").Version.Should().Be("==2.3.0");
+    }
+
+    [Fact]
+    public void Pyproject_ParsesPoetryAndOptionalDependencies()
+    {
+        var toml = @"
+[tool.poetry.dependencies]
+python = ""^3.11""
+requests = ""^2.28""
+pydantic = { version = ""^2.0"", optional = true }
+
+[tool.poetry.dev-dependencies]
+pytest = ""^7.0""
+
+[project.optional-dependencies]
+extra = [""rich>=13.0""]
+";
+        var deps = DependencyParserService.ParsePyprojectToml(toml, "pyproject.toml");
+
+        deps.Should().NotContain(d => d.Name == "python");
+        deps.Single(d => d.Name == "requests").Version.Should().Be("^2.28");
+        deps.Single(d => d.Name == "pydantic").Version.Should().Be("^2.0");
+        deps.Single(d => d.Name == "pytest").Scope.Should().Be("dev");
+        deps.Single(d => d.Name == "rich").Scope.Should().Be("optional");
+    }
+
+    [Fact]
+    public void Pyproject_ParsesPep621Array()
+    {
+        var toml = @"
+[project]
+name = ""demo""
+dependencies = [
+    ""httpx>=0.24"",
+    ""click>=8.0"",
+]
+";
+        var deps = DependencyParserService.ParsePyprojectToml(toml, "pyproject.toml");
+
+        deps.Select(d => d.Name).Should().BeEquivalentTo(new[] { "httpx", "click" });
+        deps.Single(d => d.Name == "httpx").Version.Should().Be(">=0.24");
+    }
+
+    [Fact]
+    public void SetupPy_ParsesInstallRequires()
+    {
+        var setup = @"
+from setuptools import setup
+setup(
+    name='demo',
+    install_requires=[
+        'requests>=2.0',
+        'click',
+    ],
+)
+";
+        var deps = DependencyParserService.ParseSetupPy(setup, "setup.py");
+
+        deps.Select(d => d.Name).Should().BeEquivalentTo(new[] { "requests", "click" });
+        deps.Single(d => d.Name == "requests").Version.Should().Be(">=2.0");
+    }
+
+    [Fact]
+    public void Pipfile_ParsesPackagesAndDevPackages()
+    {
+        var pipfile = @"
+[packages]
+requests = ""*""
+flask = "">=2.0""
+
+[dev-packages]
+pytest = ""*""
+";
+        var deps = DependencyParserService.ParsePipfile(pipfile, "Pipfile");
+
+        deps.Single(d => d.Name == "requests").Version.Should().BeNull(); // "*" -> null
+        deps.Single(d => d.Name == "flask").Version.Should().Be(">=2.0");
+        deps.Single(d => d.Name == "pytest").Scope.Should().Be("dev");
+    }
+
+    [Fact]
+    public void Parse_DispatchesSetupPyAndPipfileAndPackageLock()
+    {
+        var svc = new DependencyParserService();
+
+        svc.CanParse("setup.py").Should().BeTrue();
+        svc.CanParse("Pipfile").Should().BeTrue();
+        svc.CanParse("package-lock.json").Should().BeTrue();
+        svc.Parse("setup.py", "install_requires=['requests']").Should().ContainSingle(d => d.Name == "requests");
+        svc.Parse("Pipfile", "[packages]\nflask = \"*\"").Should().ContainSingle(d => d.Name == "flask");
+    }
+}


### PR DESCRIPTION
Part of **epic #245**. Dependency extraction silently mis-handled common modern setups across three ecosystems.

## #255 C# Central Package Management
- Parse `<PackageVersion Include="X" Version="Y" />` from `Directory.Packages.props` — CPM repos previously reported **null versions for every package**.
- Parse the child-element `<Version>Y</Version>` form on `PackageReference`.

## #256 Python
- Implement **setup.py** (`install_requires`) and **Pipfile** (`[packages]`/`[dev-packages]`) — both were advertised in the supported list but returned `[]` (no parser branch).
- `requirements.txt`: strip extras (`pkg[extra]`), environment markers (`; python_version…`), inline comments, and handle URL installs (`pkg @ https://…`).
- `pyproject.toml`: parse **Poetry** (`[tool.poetry.*dependencies]`) and `[project.optional-dependencies]` in addition to PEP 621 arrays.

## #257 JavaScript
- Capture `peerDependencies` (scope=peer) and `optionalDependencies` (scope=optional).
- Add **package-lock.json** parsing for resolved versions (lockfileVersion 2/3 `packages` map and v1 `dependencies`), direct deps only.

## Testing
- 11 new tests in `DependencyParserNewFormatsTests`; existing 27 `DependencyParserServiceTests` still green.
- Full unit suite **806 passed** (+11); only the 4 pre-existing git-backed failures remain.

Closes #255, #256, #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)