### PR TITLE
Language extensions, content binary detection, classifier hardening (stories #258, #259)

### DIFF
--- a/src/Andy.CodeIndex.Infrastructure/Handlers/ExtractSnippetsHandler.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Handlers/ExtractSnippetsHandler.cs
@@ -135,6 +135,15 @@ public class ExtractSnippetsHandler : ITaskHandler
             var content = await _gitService.ReadFileAsync(cloneDir, commitSha, file.Path, ct);
             if (content is null || content.Length == 0) continue;
 
+            // Skip files that are binary by content even though they passed the
+            // extension filter (renamed/extensionless binaries), so raw bytes do
+            // not pollute the snippet/embedding index. (story #258)
+            if (Services.BinaryDetectionService.ContentLooksBinary(content))
+            {
+                _logger.LogDebug("Skipping {File}: content looks binary (NUL byte)", file.Path);
+                continue;
+            }
+
             var chunks = _chunkingService.ChunkText(content, file.Path);
             foreach (var chunk in chunks)
             {

--- a/src/Andy.CodeIndex.Infrastructure/Services/BinaryDetectionService.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Services/BinaryDetectionService.cs
@@ -42,4 +42,16 @@ public class BinaryDetectionService : IBinaryDetectionService
 
         return (false, null);
     }
+
+    // Content-based detection for files that slip past the extension allowlist
+    // (renamed or extensionless binaries). A NUL byte in the leading bytes is the
+    // same heuristic git uses to classify a blob as binary. (story #258)
+    internal static bool ContentLooksBinary(string content)
+    {
+        var limit = Math.Min(content.Length, 8000);
+        for (var i = 0; i < limit; i++)
+            if (content[i] == '\0')
+                return true;
+        return false;
+    }
 }

--- a/src/Andy.CodeIndex.Infrastructure/Services/GitService.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Services/GitService.cs
@@ -15,8 +15,8 @@ public class GitService : IGitService
     private static readonly Dictionary<string, string> LanguageMap = new(StringComparer.OrdinalIgnoreCase)
     {
         [".cs"] = "csharp", [".csx"] = "csharp",
-        [".ts"] = "typescript", [".tsx"] = "typescript",
-        [".js"] = "javascript", [".jsx"] = "javascript", [".mjs"] = "javascript",
+        [".ts"] = "typescript", [".tsx"] = "typescript", [".cts"] = "typescript", [".mts"] = "typescript",
+        [".js"] = "javascript", [".jsx"] = "javascript", [".mjs"] = "javascript", [".cjs"] = "javascript",
         [".py"] = "python", [".pyi"] = "python",
         [".go"] = "go",
         [".java"] = "java",
@@ -49,6 +49,13 @@ public class GitService : IGitService
         [".vue"] = "vue",
         [".svelte"] = "svelte",
     };
+
+    /// <summary>Maps a file path to a language by extension, or null if unknown.</summary>
+    internal static string? DetectLanguage(string path)
+    {
+        var ext = Path.GetExtension(path);
+        return ext.Length > 0 && LanguageMap.TryGetValue(ext, out var lang) ? lang : null;
+    }
 
     public GitService(ILogger<GitService> logger)
     {
@@ -258,13 +265,12 @@ public class GitService : IGitService
                 continue;
 
             long.TryParse(meta[3], out var size);
-            var ext = Path.GetExtension(path);
 
             files.Add(new GitFileInfo
             {
                 Path = path,
                 Size = size,
-                Language = ext.Length > 0 && LanguageMap.TryGetValue(ext, out var lang) ? lang : null,
+                Language = DetectLanguage(path),
                 Hash = meta[2]
             });
         }
@@ -328,11 +334,7 @@ public class GitService : IGitService
 
             string? language = null;
             if (type == "blob")
-            {
-                var ext = Path.GetExtension(entryPath);
-                if (ext.Length > 0 && LanguageMap.TryGetValue(ext, out var lang))
-                    language = lang;
-            }
+                language = DetectLanguage(entryPath);
 
             entries.Add(new GitTreeEntry
             {

--- a/src/Andy.CodeIndex.Infrastructure/Services/QuestionClassifier.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Services/QuestionClassifier.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Andy.CodeIndex.Application.Interfaces;
 using Andy.CodeIndex.Domain.Enums;
+using Microsoft.Extensions.Logging;
 
 namespace Andy.CodeIndex.Infrastructure.Services;
 
@@ -11,9 +12,19 @@ public class QuestionClassifier : IQuestionClassifier
     private readonly List<OntologyDimension> _dimensions;
     private readonly EnrichmentSubtype[] _allNonChunkSubtypes;
 
-    public QuestionClassifier()
+    public QuestionClassifier(ILogger<QuestionClassifier>? logger = null)
     {
         _dimensions = LoadOntology();
+        if (_dimensions.Count == 0)
+        {
+            // Without the ontology every query silently falls back to "general"
+            // (all enrichments), disabling intent routing. Surface it loudly
+            // instead of failing quietly. (story #259)
+            logger?.LogError(
+                "Question ontology could not be loaded (Data/question-ontology.json missing or empty); " +
+                "intent classification is disabled and all queries fall back to 'general'.");
+        }
+
         _allNonChunkSubtypes = Enum.GetValues<EnrichmentSubtype>()
             .Where(s => s != EnrichmentSubtype.Chunk)
             .ToArray();
@@ -38,10 +49,7 @@ public class QuestionClassifier : IQuestionClassifier
             foreach (var q in dim.Questions)
             {
                 if (q.Keywords.Count == 0) continue;
-                var matched = q.Keywords.Count(k => words.Any(w =>
-                    w.Equals(k, StringComparison.OrdinalIgnoreCase) ||
-                    w.Contains(k, StringComparison.OrdinalIgnoreCase) ||
-                    k.Contains(w, StringComparison.OrdinalIgnoreCase)));
+                var matched = q.Keywords.Count(k => words.Any(w => KeywordMatches(w, k)));
                 var qScore = (double)matched / q.Keywords.Count;
                 if (qScore > dimBestScore)
                 {
@@ -94,6 +102,24 @@ public class QuestionClassifier : IQuestionClassifier
         RequiredEnrichments = _allNonChunkSubtypes,
         FallbackEnrichments = []
     };
+
+    // Matches a message word against an ontology keyword. Exact match, or a prefix
+    // match guarded by a minimum length so short tokens don't spuriously match
+    // (the old bidirectional Contains made "go" match "google" and "ci" match
+    // "specific", conflating unrelated dimensions). (story #259)
+    internal static bool KeywordMatches(string word, string keyword)
+    {
+        if (word.Equals(keyword, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        const int minPrefix = 4;
+        if (keyword.Length >= minPrefix && word.StartsWith(keyword, StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (word.Length >= minPrefix && keyword.StartsWith(word, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return false;
+    }
 
     private static List<string> Tokenize(string message)
     {

--- a/tests/Andy.CodeIndex.Tests.Unit/Services/DetectionAndClassifierTests.cs
+++ b/tests/Andy.CodeIndex.Tests.Unit/Services/DetectionAndClassifierTests.cs
@@ -1,0 +1,48 @@
+using Andy.CodeIndex.Infrastructure.Services;
+using FluentAssertions;
+
+namespace Andy.CodeIndex.Tests.Unit.Services;
+
+/// <summary>
+/// Covers the detection/classifier fixes in epic #245: missing language
+/// extensions (#258), content-based binary detection (#258), and the hardened
+/// QuestionClassifier keyword matching (#259).
+/// </summary>
+public class DetectionAndClassifierTests
+{
+    [Theory]
+    [InlineData("module.cts", "typescript")]
+    [InlineData("module.mts", "typescript")]
+    [InlineData("module.cjs", "javascript")]
+    [InlineData("app.ts", "typescript")]
+    [InlineData("app.mjs", "javascript")]
+    [InlineData("Program.cs", "csharp")]
+    [InlineData("notes.unknownext", null)]
+    [InlineData("Dockerfile", null)]
+    public void DetectLanguage_MapsExtensions_IncludingNewlyAdded(string path, string? expected)
+    {
+        GitService.DetectLanguage(path).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ContentLooksBinary_DetectsNulByte_ButNotPlainText()
+    {
+        BinaryDetectionService.ContentLooksBinary("public class A { }\nint x = 1;").Should().BeFalse();
+        BinaryDetectionService.ContentLooksBinary("PK\0\0binary").Should().BeTrue();
+        BinaryDetectionService.ContentLooksBinary("").Should().BeFalse();
+    }
+
+    [Theory]
+    // Exact and legitimate prefix matches still work.
+    [InlineData("test", "test", true)]
+    [InlineData("authentication", "auth", true)]
+    [InlineData("auth", "authentication", true)]
+    // Short-token false positives the old bidirectional Contains produced are gone.
+    [InlineData("go", "google", false)]
+    [InlineData("ci", "specific", false)]
+    [InlineData("go", "goroutine", false)]
+    public void KeywordMatches_AvoidsShortSubstringFalsePositives(string word, string keyword, bool expected)
+    {
+        QuestionClassifier.KeywordMatches(word, keyword).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
Completes **epic #245**.

## #258 Language & binary detection
- Map `.cts`/`.mts` → typescript and `.cjs` → javascript (previously got **null language**).
- Add **content-based binary detection** (NUL-byte scan — the heuristic git uses) and wire it into `ExtractSnippetsHandler`, so renamed/extensionless binaries that pass the extension filter no longer pollute the snippet/embedding index.
- Extract `GitService.DetectLanguage` (internal, testable; dedups two call sites).

## #259 QuestionClassifier
- Replace the bidirectional `Contains` matching — which made **"go" match "google"** and **"ci" match "specific"** — with exact-or-guarded-prefix matching (min length 4).
- **Log an error** when the ontology JSON is missing/empty instead of silently degrading every query to "general" (optional `ILogger`, DI-injected).

## Testing
- 15 new tests in `DetectionAndClassifierTests`; existing `QuestionClassifierTests`/`BinaryDetectionServiceTests`/handler tests still green.
- Full unit **821 passed** (+15); integration **102 passed**. Only the pre-existing git-backed unit tests and the pre-existing `ChatApiTests` dimension test fail (all fail on `main`).

Closes #258, #259 — completes epic #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)