### PR TITLE
Migrate to @if/@for control flow (story #263, control-flow portion)

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { RouterOutlet, RouterLink, Router, NavigationEnd } from '@angular/router';
 import { SidebarComponent } from './components/layout/sidebar.component';
 import { ApiService } from './services/api.service';
@@ -9,23 +9,29 @@ import { filter } from 'rxjs/operators';
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [CommonModule, RouterOutlet, RouterLink, SidebarComponent],
+  imports: [RouterOutlet, RouterLink, SidebarComponent],
   template: `
-    <app-sidebar *ngIf="showChrome" />
+    @if (showChrome) {
+      <app-sidebar />
+    }
     <main [class.main-content]="showChrome" [class.main-content-full]="!showChrome">
-      <div *ngIf="showChrome && llmWarning" class="health-banner health-banner-warning">
-        <i class="bi bi-exclamation-triangle-fill"></i>
-        {{ llmWarning }}
-        <a routerLink="/settings">Check Settings</a>
-      </div>
-      <div *ngIf="showChrome && embeddingWarning" class="health-banner health-banner-warning">
-        <i class="bi bi-exclamation-triangle-fill"></i>
-        {{ embeddingWarning }}
-        <a routerLink="/settings">Check Settings</a>
-      </div>
+      @if (showChrome && llmWarning) {
+        <div class="health-banner health-banner-warning">
+          <i class="bi bi-exclamation-triangle-fill"></i>
+          {{ llmWarning }}
+          <a routerLink="/settings">Check Settings</a>
+        </div>
+      }
+      @if (showChrome && embeddingWarning) {
+        <div class="health-banner health-banner-warning">
+          <i class="bi bi-exclamation-triangle-fill"></i>
+          {{ embeddingWarning }}
+          <a routerLink="/settings">Check Settings</a>
+        </div>
+      }
       <router-outlet />
     </main>
-  `,
+    `,
   styles: [`
     .main-content {
       margin-left: var(--sidebar-width);

--- a/client/src/app/components/auth/callback.component.ts
+++ b/client/src/app/components/auth/callback.component.ts
@@ -1,26 +1,30 @@
 import { Component, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-callback',
   standalone: true,
-  imports: [CommonModule],
+  imports: [],
   template: `
     <div style="display:flex;align-items:center;justify-content:center;min-height:100vh">
       <div style="text-align:center">
-        <div *ngIf="!error">
-          <div class="spinner" style="margin:0 auto 1rem"></div>
-          <p class="text-muted">Completing sign in...</p>
-        </div>
-        <div *ngIf="error">
-          <p style="color:var(--danger)">{{ error }}</p>
-          <button class="btn btn-primary" (click)="retry()">Try Again</button>
-        </div>
+        @if (!error) {
+          <div>
+            <div class="spinner" style="margin:0 auto 1rem"></div>
+            <p class="text-muted">Completing sign in...</p>
+          </div>
+        }
+        @if (error) {
+          <div>
+            <p style="color:var(--danger)">{{ error }}</p>
+            <button class="btn btn-primary" (click)="retry()">Try Again</button>
+          </div>
+        }
       </div>
     </div>
-  `
+    `
 })
 export class CallbackComponent implements OnInit {
   error = '';

--- a/client/src/app/components/auth/login.component.ts
+++ b/client/src/app/components/auth/login.component.ts
@@ -1,12 +1,12 @@
 import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { Router } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [CommonModule],
+  imports: [],
   template: `
     <div class="login-container">
       <div class="login-card">
@@ -15,26 +15,34 @@ import { AuthService } from '../../services/auth.service';
           <h1>Andy CodeIndex</h1>
         </div>
         <p>Semantic code indexing for the Andy ecosystem</p>
-
-        <div *ngIf="authEnabled && !authenticated">
-          <button class="btn btn-primary" (click)="signIn()" [disabled]="signingIn">
-            {{ signingIn ? 'Redirecting...' : 'Sign in with Andy Auth' }}
-          </button>
-          <div *ngIf="error" class="error-msg">{{ error }}</div>
-        </div>
-
-        <div *ngIf="authEnabled && authenticated">
-          <p><strong>Welcome back, {{ userName }}</strong></p>
-          <button class="btn btn-primary" (click)="goToApp()" style="margin-right:0.5rem">Go to Repositories</button>
-          <button class="btn btn-secondary" (click)="signOut()">Sign Out</button>
-        </div>
-
-        <p *ngIf="!authEnabled" class="text-muted">
-          Authentication not configured. Running in dev mode.
-        </p>
+    
+        @if (authEnabled && !authenticated) {
+          <div>
+            <button class="btn btn-primary" (click)="signIn()" [disabled]="signingIn">
+              {{ signingIn ? 'Redirecting...' : 'Sign in with Andy Auth' }}
+            </button>
+            @if (error) {
+              <div class="error-msg">{{ error }}</div>
+            }
+          </div>
+        }
+    
+        @if (authEnabled && authenticated) {
+          <div>
+            <p><strong>Welcome back, {{ userName }}</strong></p>
+            <button class="btn btn-primary" (click)="goToApp()" style="margin-right:0.5rem">Go to Repositories</button>
+            <button class="btn btn-secondary" (click)="signOut()">Sign Out</button>
+          </div>
+        }
+    
+        @if (!authEnabled) {
+          <p class="text-muted">
+            Authentication not configured. Running in dev mode.
+          </p>
+        }
       </div>
     </div>
-  `,
+    `,
   styles: [`
     .login-container {
       display: flex; align-items: center; justify-content: center;

--- a/client/src/app/components/chat/chat.component.ts
+++ b/client/src/app/components/chat/chat.component.ts
@@ -77,29 +77,35 @@ interface ConversationGroup {
         <div class="sidebar-section">
           <h3 class="sidebar-title">Quick Questions</h3>
           <input class="form-control sidebar-search" [(ngModel)]="searchQuery"
-                 placeholder="Search questions..." (input)="filterQuestions()">
+            placeholder="Search questions..." (input)="filterQuestions()">
         </div>
-
+    
         <div class="sidebar-section">
           <div class="category-grid">
-            <button *ngFor="let cat of allCategories" class="category-tile"
-                    [class.active]="activeCategory === cat.name"
-                    (click)="selectCategory(cat.name)">
-              <span class="category-name">{{ cat.name }}</span>
-              <span class="category-count">{{ cat.questions.length }}</span>
-            </button>
+            @for (cat of allCategories; track cat) {
+              <button class="category-tile"
+                [class.active]="activeCategory === cat.name"
+                (click)="selectCategory(cat.name)">
+                <span class="category-name">{{ cat.name }}</span>
+                <span class="category-count">{{ cat.questions.length }}</span>
+              </button>
+            }
           </div>
         </div>
-
+    
         <div class="sidebar-section question-list">
-          <button *ngFor="let q of visibleQuestions" class="question-item" (click)="askSuggestion(q)">
-            {{ q }}
-          </button>
-          <div *ngIf="visibleQuestions.length === 0" class="text-muted" style="padding:0.5rem;font-size:var(--font-xs)">
-            No matching questions.
-          </div>
+          @for (q of visibleQuestions; track q) {
+            <button class="question-item" (click)="askSuggestion(q)">
+              {{ q }}
+            </button>
+          }
+          @if (visibleQuestions.length === 0) {
+            <div class="text-muted" style="padding:0.5rem;font-size:var(--font-xs)">
+              No matching questions.
+            </div>
+          }
         </div>
-
+    
         <div class="sidebar-section conversations-section">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem">
             <h3 class="sidebar-title" style="margin:0">Conversations</h3>
@@ -108,43 +114,53 @@ interface ConversationGroup {
             </button>
           </div>
           <input class="form-control sidebar-search" [(ngModel)]="convSearchQuery"
-                 placeholder="Search conversations..." (input)="onConvSearchInput()"
-                 style="margin-bottom:0.5rem">
+            placeholder="Search conversations..." (input)="onConvSearchInput()"
+            style="margin-bottom:0.5rem">
           <div class="conversation-list">
-            <ng-container *ngFor="let group of groupedConversations">
-              <div class="conv-group-header" *ngIf="group.conversations.length > 0">{{ group.label }}</div>
-              <div *ngFor="let conv of group.conversations" class="conversation-item"
-                   [class.active]="conversationId === conv.id"
-                   (click)="resumeConversation(conv.id)">
-                <div class="conv-title-row">
-                  <div class="conv-title" *ngIf="editingConvId !== conv.id"
-                       (dblclick)="startRename(conv, $event)">{{ conv.title }}</div>
-                  <input *ngIf="editingConvId === conv.id" class="conv-title-input"
-                         [(ngModel)]="editingTitle"
-                         (keydown.enter)="saveRename(conv)"
-                         (keydown.escape)="cancelRename()"
-                         (blur)="saveRename(conv)"
-                         (click)="$event.stopPropagation()">
-                  <button class="btn-icon-sm" (click)="togglePin(conv, $event)"
-                          [title]="conv.isPinned ? 'Unpin' : 'Pin'">
-                    <i class="bi" [ngClass]="conv.isPinned ? 'bi-pin-fill' : 'bi-pin'"></i>
-                  </button>
+            @for (group of groupedConversations; track group) {
+              @if (group.conversations.length > 0) {
+                <div class="conv-group-header">{{ group.label }}</div>
+              }
+              @for (conv of group.conversations; track conv) {
+                <div class="conversation-item"
+                  [class.active]="conversationId === conv.id"
+                  (click)="resumeConversation(conv.id)">
+                  <div class="conv-title-row">
+                    @if (editingConvId !== conv.id) {
+                      <div class="conv-title"
+                      (dblclick)="startRename(conv, $event)">{{ conv.title }}</div>
+                    }
+                    @if (editingConvId === conv.id) {
+                      <input class="conv-title-input"
+                        [(ngModel)]="editingTitle"
+                        (keydown.enter)="saveRename(conv)"
+                        (keydown.escape)="cancelRename()"
+                        (blur)="saveRename(conv)"
+                        (click)="$event.stopPropagation()">
+                    }
+                    <button class="btn-icon-sm" (click)="togglePin(conv, $event)"
+                      [title]="conv.isPinned ? 'Unpin' : 'Pin'">
+                      <i class="bi" [ngClass]="conv.isPinned ? 'bi-pin-fill' : 'bi-pin'"></i>
+                    </button>
+                  </div>
+                  <div class="conv-meta">
+                    <span>{{ formatTimeAgo(conv.updatedAt) }}</span>
+                    <button class="btn-icon-sm" (click)="deleteConversation(conv.id, $event)" title="Delete">
+                      <i class="bi bi-trash3"></i>
+                    </button>
+                  </div>
                 </div>
-                <div class="conv-meta">
-                  <span>{{ formatTimeAgo(conv.updatedAt) }}</span>
-                  <button class="btn-icon-sm" (click)="deleteConversation(conv.id, $event)" title="Delete">
-                    <i class="bi bi-trash3"></i>
-                  </button>
-                </div>
+              }
+            }
+            @if (conversations.length === 0) {
+              <div class="text-muted" style="font-size:var(--font-xs);padding:0.25rem">
+                No conversations yet.
               </div>
-            </ng-container>
-            <div *ngIf="conversations.length === 0" class="text-muted" style="font-size:var(--font-xs);padding:0.25rem">
-              No conversations yet.
-            </div>
+            }
           </div>
         </div>
       </aside>
-
+    
       <!-- Right Panel: Chat -->
       <main class="chat-main">
         <div class="chat-header">
@@ -152,62 +168,90 @@ interface ConversationGroup {
           <div style="display:flex;gap:0.75rem;align-items:center">
             <select class="form-control" [(ngModel)]="selectedRepo" (ngModelChange)="onRepoChange($event)" style="width:180px">
               <option value="">All Repositories</option>
-              <option *ngFor="let r of repos" [value]="r.id">{{ r.name }}</option>
+              @for (r of repos; track r) {
+                <option [value]="r.id">{{ r.name }}</option>
+              }
             </select>
-            <select *ngIf="selectedRepo && (repoBranches.length > 0 || repoTags.length > 0)" class="form-control" [(ngModel)]="selectedRef" style="width:160px">
-              <option value="">All branches</option>
-              <optgroup label="Branches" *ngIf="repoBranches.length > 0">
-                <option *ngFor="let b of repoBranches" [value]="b.name">{{ b.name }}{{ b.isDefault ? ' (default)' : '' }}</option>
-              </optgroup>
-              <optgroup label="Tags" *ngIf="repoTags.length > 0">
-                <option *ngFor="let t of repoTags" [value]="t.name">{{ t.name }}</option>
-              </optgroup>
-            </select>
-            <span class="badge badge-muted" *ngIf="!chatAvailable">LLM not configured</span>
+            @if (selectedRepo && (repoBranches.length > 0 || repoTags.length > 0)) {
+              <select class="form-control" [(ngModel)]="selectedRef" style="width:160px">
+                <option value="">All branches</option>
+                @if (repoBranches.length > 0) {
+                  <optgroup label="Branches">
+                    @for (b of repoBranches; track b) {
+                      <option [value]="b.name">{{ b.name }}{{ b.isDefault ? ' (default)' : '' }}</option>
+                    }
+                  </optgroup>
+                }
+                @if (repoTags.length > 0) {
+                  <optgroup label="Tags">
+                    @for (t of repoTags; track t) {
+                      <option [value]="t.name">{{ t.name }}</option>
+                    }
+                  </optgroup>
+                }
+              </select>
+            }
+            @if (!chatAvailable) {
+              <span class="badge badge-muted">LLM not configured</span>
+            }
           </div>
         </div>
-
+    
         <div class="chat-messages" #messagesContainer>
-          <div *ngIf="messages.length === 0" class="empty-chat">
-            <i class="bi bi-chat-dots"></i>
-            <h3>Ask about your codebase</h3>
-            <p class="text-muted">Select a question from the left panel, or type your own below.</p>
-          </div>
-
-          <div *ngFor="let msg of messages" class="message" [ngClass]="msg.role">
-            <div class="message-bubble">
-              <div class="message-content" [innerHTML]="formatContent(msg.content)"></div>
-              <div *ngIf="msg.sources && msg.sources.length > 0" class="sources-toggle">
-                <button class="btn btn-sm btn-secondary" (click)="msg.showSources = !msg.showSources" style="font-size:var(--font-xs)">
-                  <i class="bi" [ngClass]="msg.showSources ? 'bi-chevron-up' : 'bi-chevron-down'"></i>
-                  {{ msg.sources.length }} sources
-                </button>
-                <div *ngIf="msg.showSources" class="sources-list">
-                  <div *ngFor="let s of msg.sources" class="source-item">
-                    <code>{{ s.repositoryName }}/{{ s.filePath }}</code>
-                    <span class="text-muted" *ngIf="s.startLine"> :{{ s.startLine }}</span>
+          @if (messages.length === 0) {
+            <div class="empty-chat">
+              <i class="bi bi-chat-dots"></i>
+              <h3>Ask about your codebase</h3>
+              <p class="text-muted">Select a question from the left panel, or type your own below.</p>
+            </div>
+          }
+    
+          @for (msg of messages; track msg) {
+            <div class="message" [ngClass]="msg.role">
+              <div class="message-bubble">
+                <div class="message-content" [innerHTML]="formatContent(msg.content)"></div>
+                @if (msg.sources && msg.sources.length > 0) {
+                  <div class="sources-toggle">
+                    <button class="btn btn-sm btn-secondary" (click)="msg.showSources = !msg.showSources" style="font-size:var(--font-xs)">
+                      <i class="bi" [ngClass]="msg.showSources ? 'bi-chevron-up' : 'bi-chevron-down'"></i>
+                      {{ msg.sources.length }} sources
+                    </button>
+                    @if (msg.showSources) {
+                      <div class="sources-list">
+                        @for (s of msg.sources; track s) {
+                          <div class="source-item">
+                            <code>{{ s.repositoryName }}/{{ s.filePath }}</code>
+                            @if (s.startLine) {
+                              <span class="text-muted"> :{{ s.startLine }}</span>
+                            }
+                          </div>
+                        }
+                      </div>
+                    }
                   </div>
-                </div>
+                }
               </div>
             </div>
-          </div>
-
-          <div *ngIf="sending" class="message assistant">
-            <div class="message-bubble"><div class="spinner" style="width:1.5rem;height:1.5rem"></div></div>
-          </div>
+          }
+    
+          @if (sending) {
+            <div class="message assistant">
+              <div class="message-bubble"><div class="spinner" style="width:1.5rem;height:1.5rem"></div></div>
+            </div>
+          }
         </div>
-
+    
         <div class="chat-input">
           <textarea class="form-control" [(ngModel)]="input" placeholder="Ask about your code..."
-                    (keydown.enter)="onEnter($event)" rows="1"
-                    [disabled]="sending"></textarea>
+            (keydown.enter)="onEnter($event)" rows="1"
+          [disabled]="sending"></textarea>
           <button class="btn btn-primary" (click)="send()" [disabled]="sending || !input.trim()">
             <i class="bi bi-send"></i>
           </button>
         </div>
       </main>
     </div>
-  `,
+    `,
   styles: [`
     /* --- Two-panel layout --- */
     .chat-layout { display: flex; height: calc(100vh - 4rem); gap: 0; }

--- a/client/src/app/components/dashboard/dashboard.component.ts
+++ b/client/src/app/components/dashboard/dashboard.component.ts
@@ -19,74 +19,91 @@ import { RepositorySparklineComponent } from '../repositories/repository-sparkli
         <i class="bi bi-folder2-open"></i> All Repositories
       </a>
     </div>
-
-    <div class="card" *ngIf="loading">
-      <div style="display:flex;justify-content:center;padding:2rem"><div class="spinner"></div></div>
-    </div>
-
-    <div class="empty-state card" *ngIf="!loading && pinnedRepos.length === 0">
-      <i class="bi bi-pin-angle"></i>
-      <h3>No pinned repositories</h3>
-      <p>Pin repositories from the <a routerLink="/repositories">repository list</a> for quick access.</p>
-    </div>
-
-    <div class="dashboard-grid" *ngIf="!loading && pinnedRepos.length > 0">
-      <div class="dashboard-card card" *ngFor="let repo of pinnedRepos">
-        <div class="card-header">
-          <div class="card-title-row">
-            <a [routerLink]="['/repositories', repo.id]" class="repo-name">{{ repo.name }}</a>
-            <span class="badge" [ngClass]="statusClass(repo.status)">{{ repo.status }}</span>
-          </div>
-          <div class="card-meta">
-            <span class="badge badge-muted">{{ repo.provider }}</span>
-            <span class="text-muted" *ngIf="repo.organization">{{ repo.organization }}</span>
-          </div>
-        </div>
-
-        <div class="card-stats">
-          <div class="stat">
-            <span class="stat-value">{{ repo.stats?.commitCount || 0 }}</span>
-            <span class="stat-label">Commits</span>
-          </div>
-          <div class="stat">
-            <span class="stat-value">{{ repo.stats?.enrichmentCount || 0 }}</span>
-            <span class="stat-label">Enrichments</span>
-            <span class="stat-sub" *ngIf="repo.stats?.storageSizeBytes" style="font-size:var(--font-xs);color:var(--text-muted)">{{ formatBytes(repo.stats!.storageSizeBytes) }}</span>
-          </div>
-          <div class="stat">
-            <span class="stat-value">{{ repo.stats?.hasEmbeddings ? (repo.stats?.embeddingCount || 0) : '--' }}</span>
-            <span class="stat-label">Embeddings</span>
-          </div>
-        </div>
-
-        <div class="card-activity" *ngIf="sparklines.get(repo.id)">
-          <app-repository-sparkline [weeklyData]="sparklines.get(repo.id)!.weeklyData"></app-repository-sparkline>
-        </div>
-
-        <div class="card-footer">
-          <span class="text-muted last-synced">
-            <i class="bi bi-clock"></i>
-            {{ repo.lastSyncedAt ? (repo.lastSyncedAt | date:'short') : 'Never synced' }}
-          </span>
-          <div class="card-actions">
-            <button class="btn btn-sm btn-secondary" (click)="sync(repo)" [disabled]="syncing[repo.id]"
-                    title="Sync repository">
-              <span *ngIf="!syncing[repo.id]"><i class="bi bi-arrow-repeat"></i></span>
-              <span *ngIf="syncing[repo.id]"><div class="spinner" style="width:14px;height:14px;display:inline-block;vertical-align:middle"></div></span>
-            </button>
-            <a [routerLink]="['/repositories', repo.id]" class="btn btn-sm btn-secondary" title="View details">
-              <i class="bi bi-eye"></i>
-            </a>
-            <button class="btn btn-sm btn-secondary" (click)="unpin(repo.id)" title="Unpin from dashboard">
-              <i class="bi bi-pin-fill"></i>
-            </button>
-          </div>
-        </div>
+    
+    @if (loading) {
+      <div class="card">
+        <div style="display:flex;justify-content:center;padding:2rem"><div class="spinner"></div></div>
       </div>
-    </div>
-
-    <div class="error-message" *ngIf="error">{{ error }}</div>
-  `,
+    }
+    
+    @if (!loading && pinnedRepos.length === 0) {
+      <div class="empty-state card">
+        <i class="bi bi-pin-angle"></i>
+        <h3>No pinned repositories</h3>
+        <p>Pin repositories from the <a routerLink="/repositories">repository list</a> for quick access.</p>
+      </div>
+    }
+    
+    @if (!loading && pinnedRepos.length > 0) {
+      <div class="dashboard-grid">
+        @for (repo of pinnedRepos; track repo) {
+          <div class="dashboard-card card">
+            <div class="card-header">
+              <div class="card-title-row">
+                <a [routerLink]="['/repositories', repo.id]" class="repo-name">{{ repo.name }}</a>
+                <span class="badge" [ngClass]="statusClass(repo.status)">{{ repo.status }}</span>
+              </div>
+              <div class="card-meta">
+                <span class="badge badge-muted">{{ repo.provider }}</span>
+                @if (repo.organization) {
+                  <span class="text-muted">{{ repo.organization }}</span>
+                }
+              </div>
+            </div>
+            <div class="card-stats">
+              <div class="stat">
+                <span class="stat-value">{{ repo.stats?.commitCount || 0 }}</span>
+                <span class="stat-label">Commits</span>
+              </div>
+              <div class="stat">
+                <span class="stat-value">{{ repo.stats?.enrichmentCount || 0 }}</span>
+                <span class="stat-label">Enrichments</span>
+                @if (repo.stats?.storageSizeBytes) {
+                  <span class="stat-sub" style="font-size:var(--font-xs);color:var(--text-muted)">{{ formatBytes(repo.stats!.storageSizeBytes) }}</span>
+                }
+              </div>
+              <div class="stat">
+                <span class="stat-value">{{ repo.stats?.hasEmbeddings ? (repo.stats?.embeddingCount || 0) : '--' }}</span>
+                <span class="stat-label">Embeddings</span>
+              </div>
+            </div>
+            @if (sparklines.get(repo.id)) {
+              <div class="card-activity">
+                <app-repository-sparkline [weeklyData]="sparklines.get(repo.id)!.weeklyData"></app-repository-sparkline>
+              </div>
+            }
+            <div class="card-footer">
+              <span class="text-muted last-synced">
+                <i class="bi bi-clock"></i>
+                {{ repo.lastSyncedAt ? (repo.lastSyncedAt | date:'short') : 'Never synced' }}
+              </span>
+              <div class="card-actions">
+                <button class="btn btn-sm btn-secondary" (click)="sync(repo)" [disabled]="syncing[repo.id]"
+                  title="Sync repository">
+                  @if (!syncing[repo.id]) {
+                    <span><i class="bi bi-arrow-repeat"></i></span>
+                  }
+                  @if (syncing[repo.id]) {
+                    <span><div class="spinner" style="width:14px;height:14px;display:inline-block;vertical-align:middle"></div></span>
+                  }
+                </button>
+                <a [routerLink]="['/repositories', repo.id]" class="btn btn-sm btn-secondary" title="View details">
+                  <i class="bi bi-eye"></i>
+                </a>
+                <button class="btn btn-sm btn-secondary" (click)="unpin(repo.id)" title="Unpin from dashboard">
+                  <i class="bi bi-pin-fill"></i>
+                </button>
+              </div>
+            </div>
+          </div>
+        }
+      </div>
+    }
+    
+    @if (error) {
+      <div class="error-message">{{ error }}</div>
+    }
+    `,
   styles: [`
     .dashboard-grid {
       display: grid;

--- a/client/src/app/components/discovery/discovery.component.ts
+++ b/client/src/app/components/discovery/discovery.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { CommonModule } from '@angular/common';
+
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
 
@@ -23,12 +23,12 @@ interface DiscoveredRepo {
 @Component({
   selector: 'app-discovery',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [FormsModule],
   template: `
     <div class="page-header">
       <h1>Discover Repositories</h1>
     </div>
-
+    
     <div class="card mb-2">
       <div class="discover-form">
         <div class="discover-field">
@@ -42,10 +42,12 @@ interface DiscoveredRepo {
           <label>Organization</label>
           <input class="form-control" [(ngModel)]="org" placeholder="e.g., rivoli-ai">
         </div>
-        <div class="discover-field" *ngIf="provider === 'azure-devops'">
-          <label>Project (optional)</label>
-          <input class="form-control" [(ngModel)]="project" placeholder="e.g., MyProject">
-        </div>
+        @if (provider === 'azure-devops') {
+          <div class="discover-field">
+            <label>Project (optional)</label>
+            <input class="form-control" [(ngModel)]="project" placeholder="e.g., MyProject">
+          </div>
+        }
         <div class="discover-field">
           <label>PAT (optional)</label>
           <input class="form-control" type="password" [(ngModel)]="pat" placeholder="For private orgs">
@@ -58,71 +60,102 @@ interface DiscoveredRepo {
         </div>
       </div>
     </div>
-
-    <div *ngIf="discovering" style="display:flex;justify-content:center;padding:2rem"><div class="spinner"></div></div>
-
-    <div *ngIf="!discovering && repos.length > 0">
-      <div class="card mb-2" style="padding:0.75rem 1rem">
-        <div style="display:flex;gap:0.75rem;flex-wrap:wrap;align-items:center">
-          <input class="form-control" [(ngModel)]="repoSearch" placeholder="Filter by name..." style="width:200px;padding:0.375rem 0.75rem">
-          <select class="form-control" [(ngModel)]="sortBy" style="width:150px;padding:0.375rem 0.75rem">
-            <option value="name">Sort: Name</option>
-            <option value="stars">Sort: Stars</option>
-            <option value="updated">Sort: Last Updated</option>
-            <option value="size">Sort: Size</option>
-          </select>
-          <select class="form-control" [(ngModel)]="languageFilter" style="width:150px;padding:0.375rem 0.75rem">
-            <option value="">All Languages</option>
-            <option *ngFor="let lang of availableLanguages" [value]="lang">{{ lang }}</option>
-          </select>
-          <label style="display:flex;align-items:center;gap:0.375rem;font-size:0.875rem;cursor:pointer;margin:0">
-            <input type="checkbox" [(ngModel)]="hideTracked"> Hide already tracked
-          </label>
-          <button class="btn btn-sm btn-secondary" (click)="selectAllVisible()">Select All</button>
-          <button class="btn btn-sm btn-secondary" (click)="deselectAll()">Deselect All</button>
-          <span class="text-muted" style="margin-left:auto;font-size:0.8125rem">
-            Showing {{ filteredRepos.length }} of {{ repos.length }} ({{ trackedCount }} tracked)
-          </span>
-          <button class="btn btn-primary btn-sm" (click)="addSelected()" [disabled]="adding || selectedCount === 0">
-            Add {{ selectedCount }} Selected
-          </button>
-        </div>
-      </div>
-
-      <div class="card" *ngFor="let repo of filteredRepos"
-           [class.tracked-repo]="repo.alreadyTracked"
-           style="margin-bottom:0.5rem;padding:1rem">
-        <div style="display:flex;align-items:center;gap:0.75rem">
-          <input type="checkbox" [(ngModel)]="repo.selected" [disabled]="repo.alreadyTracked" style="width:18px;height:18px"
-                 *ngIf="!repo.alreadyTracked">
-          <i class="bi bi-check-circle-fill" *ngIf="repo.alreadyTracked" style="color:var(--success);font-size:1.125rem;min-width:18px"></i>
-          <div style="flex:1">
-            <strong>{{ repo.name }}</strong>
-            <span class="text-muted" style="margin-left:0.5rem;font-size:0.8125rem">{{ repo.fullName }}</span>
-            <span class="badge badge-success" style="margin-left:0.5rem" *ngIf="repo.alreadyTracked">Already Tracked</span>
+    
+    @if (discovering) {
+      <div style="display:flex;justify-content:center;padding:2rem"><div class="spinner"></div></div>
+    }
+    
+    @if (!discovering && repos.length > 0) {
+      <div>
+        <div class="card mb-2" style="padding:0.75rem 1rem">
+          <div style="display:flex;gap:0.75rem;flex-wrap:wrap;align-items:center">
+            <input class="form-control" [(ngModel)]="repoSearch" placeholder="Filter by name..." style="width:200px;padding:0.375rem 0.75rem">
+            <select class="form-control" [(ngModel)]="sortBy" style="width:150px;padding:0.375rem 0.75rem">
+              <option value="name">Sort: Name</option>
+              <option value="stars">Sort: Stars</option>
+              <option value="updated">Sort: Last Updated</option>
+              <option value="size">Sort: Size</option>
+            </select>
+            <select class="form-control" [(ngModel)]="languageFilter" style="width:150px;padding:0.375rem 0.75rem">
+              <option value="">All Languages</option>
+              @for (lang of availableLanguages; track lang) {
+                <option [value]="lang">{{ lang }}</option>
+              }
+            </select>
+            <label style="display:flex;align-items:center;gap:0.375rem;font-size:0.875rem;cursor:pointer;margin:0">
+              <input type="checkbox" [(ngModel)]="hideTracked"> Hide already tracked
+            </label>
+            <button class="btn btn-sm btn-secondary" (click)="selectAllVisible()">Select All</button>
+            <button class="btn btn-sm btn-secondary" (click)="deselectAll()">Deselect All</button>
+            <span class="text-muted" style="margin-left:auto;font-size:0.8125rem">
+              Showing {{ filteredRepos.length }} of {{ repos.length }} ({{ trackedCount }} tracked)
+            </span>
+            <button class="btn btn-primary btn-sm" (click)="addSelected()" [disabled]="adding || selectedCount === 0">
+              Add {{ selectedCount }} Selected
+            </button>
           </div>
-          <span class="badge badge-muted">{{ repo.provider }}</span>
-          <span class="text-muted" style="font-size:0.8125rem" *ngIf="repo.defaultBranch">{{ repo.defaultBranch }}</span>
         </div>
-        <div style="display:flex;gap:0.75rem;align-items:center;margin-top:0.375rem;flex-wrap:wrap">
-          <span class="text-muted" style="font-size:0.8125rem" *ngIf="repo.stars != null" title="Stars">&#9733; {{ repo.stars }}</span>
-          <span class="badge badge-info" *ngIf="repo.language">{{ repo.language }}</span>
-          <span class="text-muted" style="font-size:0.8125rem" *ngIf="repo.lastPushedAt" title="Last pushed">{{ timeAgo(repo.lastPushedAt) }}</span>
-          <span class="text-muted" style="font-size:0.8125rem" *ngIf="repo.size != null" title="Repository size">{{ formatSize(repo.size) }}</span>
-        </div>
-        <div class="text-muted" style="font-size:0.8125rem;margin-top:0.25rem" *ngIf="repo.description">{{ repo.description }}</div>
+        @for (repo of filteredRepos; track repo) {
+          <div class="card"
+            [class.tracked-repo]="repo.alreadyTracked"
+            style="margin-bottom:0.5rem;padding:1rem">
+            <div style="display:flex;align-items:center;gap:0.75rem">
+              @if (!repo.alreadyTracked) {
+                <input type="checkbox" [(ngModel)]="repo.selected" [disabled]="repo.alreadyTracked" style="width:18px;height:18px"
+                  >
+              }
+              @if (repo.alreadyTracked) {
+                <i class="bi bi-check-circle-fill" style="color:var(--success);font-size:1.125rem;min-width:18px"></i>
+              }
+              <div style="flex:1">
+                <strong>{{ repo.name }}</strong>
+                <span class="text-muted" style="margin-left:0.5rem;font-size:0.8125rem">{{ repo.fullName }}</span>
+                @if (repo.alreadyTracked) {
+                  <span class="badge badge-success" style="margin-left:0.5rem">Already Tracked</span>
+                }
+              </div>
+              <span class="badge badge-muted">{{ repo.provider }}</span>
+              @if (repo.defaultBranch) {
+                <span class="text-muted" style="font-size:0.8125rem">{{ repo.defaultBranch }}</span>
+              }
+            </div>
+            <div style="display:flex;gap:0.75rem;align-items:center;margin-top:0.375rem;flex-wrap:wrap">
+              @if (repo.stars != null) {
+                <span class="text-muted" style="font-size:0.8125rem" title="Stars">&#9733; {{ repo.stars }}</span>
+              }
+              @if (repo.language) {
+                <span class="badge badge-info">{{ repo.language }}</span>
+              }
+              @if (repo.lastPushedAt) {
+                <span class="text-muted" style="font-size:0.8125rem" title="Last pushed">{{ timeAgo(repo.lastPushedAt) }}</span>
+              }
+              @if (repo.size != null) {
+                <span class="text-muted" style="font-size:0.8125rem" title="Repository size">{{ formatSize(repo.size) }}</span>
+              }
+            </div>
+            @if (repo.description) {
+              <div class="text-muted" style="font-size:0.8125rem;margin-top:0.25rem">{{ repo.description }}</div>
+            }
+          </div>
+        }
       </div>
-    </div>
-
-    <div *ngIf="!discovering && repos.length === 0 && searched" class="empty-state card">
-      <i class="bi bi-search"></i>
-      <h3>No repositories found</h3>
-      <p>Check the organization name and try again.</p>
-    </div>
-
-    <div *ngIf="error" class="card" style="color:var(--danger);margin-top:1rem">{{ error }}</div>
-    <div *ngIf="addMessage" class="card" style="color:var(--success);margin-top:1rem">{{ addMessage }}</div>
-  `,
+    }
+    
+    @if (!discovering && repos.length === 0 && searched) {
+      <div class="empty-state card">
+        <i class="bi bi-search"></i>
+        <h3>No repositories found</h3>
+        <p>Check the organization name and try again.</p>
+      </div>
+    }
+    
+    @if (error) {
+      <div class="card" style="color:var(--danger);margin-top:1rem">{{ error }}</div>
+    }
+    @if (addMessage) {
+      <div class="card" style="color:var(--success);margin-top:1rem">{{ addMessage }}</div>
+    }
+    `,
   styles: [`
     .discover-form { display: flex; gap: 1rem; align-items: flex-start; flex-wrap: wrap; }
     .discover-field { display: flex; flex-direction: column; min-width: 160px; }

--- a/client/src/app/components/docs/docs.component.ts
+++ b/client/src/app/components/docs/docs.component.ts
@@ -30,45 +30,57 @@ interface DocPage {
           <span>Documentation</span>
         </div>
         <nav class="docs-nav">
-          <a *ngFor="let page of pages"
-             [routerLink]="['/docs', page.slug]"
-             routerLinkActive="active"
-             class="docs-nav-item">
-            <i class="bi" [ngClass]="page.icon"></i>
-            <span>{{ page.title }}</span>
-          </a>
+          @for (page of pages; track page) {
+            <a
+              [routerLink]="['/docs', page.slug]"
+              routerLinkActive="active"
+              class="docs-nav-item">
+              <i class="bi" [ngClass]="page.icon"></i>
+              <span>{{ page.title }}</span>
+            </a>
+          }
         </nav>
       </aside>
-
+    
       <!-- Main content -->
       <main class="docs-content">
-        <div *ngIf="loading" class="docs-loading">
-          <i class="bi bi-arrow-repeat spin"></i> Loading...
-        </div>
-        <div *ngIf="error" class="docs-error">
-          <i class="bi bi-exclamation-triangle"></i> {{ error }}
-        </div>
-        <article *ngIf="!loading && !error"
-                 class="docs-article"
-                 [innerHTML]="renderedHtml">
-        </article>
+        @if (loading) {
+          <div class="docs-loading">
+            <i class="bi bi-arrow-repeat spin"></i> Loading...
+          </div>
+        }
+        @if (error) {
+          <div class="docs-error">
+            <i class="bi bi-exclamation-triangle"></i> {{ error }}
+          </div>
+        }
+        @if (!loading && !error) {
+          <article
+            class="docs-article"
+            [innerHTML]="renderedHtml">
+          </article>
+        }
       </main>
-
+    
       <!-- Page TOC (right sidebar) -->
-      <aside class="docs-page-toc" *ngIf="pageToc.length > 0">
-        <div class="page-toc-header">On this page</div>
-        <nav class="page-toc-nav">
-          <a *ngFor="let entry of pageToc"
-             [href]="'#' + entry.id"
-             class="page-toc-item"
-             [class.level-3]="entry.level === 3"
-             (click)="scrollToHeading($event, entry.id)">
-            {{ entry.text }}
-          </a>
-        </nav>
-      </aside>
+      @if (pageToc.length > 0) {
+        <aside class="docs-page-toc">
+          <div class="page-toc-header">On this page</div>
+          <nav class="page-toc-nav">
+            @for (entry of pageToc; track entry) {
+              <a
+                [href]="'#' + entry.id"
+                class="page-toc-item"
+                [class.level-3]="entry.level === 3"
+                (click)="scrollToHeading($event, entry.id)">
+                {{ entry.text }}
+              </a>
+            }
+          </nav>
+        </aside>
+      }
     </div>
-  `,
+    `,
   styles: [`
     .docs-layout {
       display: grid;

--- a/client/src/app/components/enrichments/enrichment-browser.component.ts
+++ b/client/src/app/components/enrichments/enrichment-browser.component.ts
@@ -14,7 +14,7 @@ import { environment } from '../../../environments/environment';
     <div class="page-header">
       <h1>Enrichments</h1>
     </div>
-
+    
     <div class="card mb-2">
       <h3 style="font-size:var(--font-sm);margin-bottom:0.5rem">What are enrichments?</h3>
       <p class="text-muted" style="font-size:var(--font-xs);margin-bottom:0.75rem">
@@ -55,77 +55,111 @@ import { environment } from '../../../environments/environment';
         <div><strong>Tech Stack</strong> -- Technology stack detection: backend/frontend frameworks, databases, infrastructure, and language breakdown</div>
       </div>
     </div>
-
+    
     <!-- Summary bar -->
-    <div class="card mb-2" *ngIf="!loading && typeCounts.length > 0" style="padding:0.75rem 1rem">
-      <div style="display:flex;gap:1rem;flex-wrap:wrap;align-items:center;font-size:var(--font-xs)">
-        <span style="font-weight:600">{{ totalCount }} enrichments<span *ngIf="globalStorageSizeBytes > 0"> &middot; {{ formatBytes(globalStorageSizeBytes) }}</span></span>
-        <span *ngFor="let tc of typeCounts" style="display:inline-flex;align-items:center;gap:0.25rem">
-          <span class="badge badge-muted">{{ getSubtypeLabel(tc.subtype) }}</span>
-          <span>{{ tc.count }}</span>
-        </span>
+    @if (!loading && typeCounts.length > 0) {
+      <div class="card mb-2" style="padding:0.75rem 1rem">
+        <div style="display:flex;gap:1rem;flex-wrap:wrap;align-items:center;font-size:var(--font-xs)">
+          <span style="font-weight:600">{{ totalCount }} enrichments@if (globalStorageSizeBytes > 0) {
+            <span> &middot; {{ formatBytes(globalStorageSizeBytes) }}</span>
+          }</span>
+          @for (tc of typeCounts; track tc) {
+            <span style="display:inline-flex;align-items:center;gap:0.25rem">
+              <span class="badge badge-muted">{{ getSubtypeLabel(tc.subtype) }}</span>
+              <span>{{ tc.count }}</span>
+            </span>
+          }
+        </div>
       </div>
-    </div>
-
+    }
+    
     <!-- Filters -->
     <div class="card mb-2">
       <div style="display:flex;gap:1rem;flex-wrap:wrap">
         <div class="form-group" style="margin-bottom:0">
           <select class="form-control" [(ngModel)]="typeFilter" (change)="onTypeChange()" style="width:180px">
             <option value="">All Types</option>
-            <option *ngFor="let t of typeOptions" [value]="t">{{ t }}</option>
+            @for (t of typeOptions; track t) {
+              <option [value]="t">{{ t }}</option>
+            }
           </select>
         </div>
         <div class="form-group" style="margin-bottom:0">
           <select class="form-control" [(ngModel)]="subtypeFilter" (change)="loadEnrichments()" style="width:180px">
             <option value="">All Subtypes</option>
-            <option *ngFor="let st of availableSubtypes" [value]="st.value">{{ st.label }}</option>
+            @for (st of availableSubtypes; track st) {
+              <option [value]="st.value">{{ st.label }}</option>
+            }
           </select>
         </div>
         <div class="form-group" style="margin-bottom:0">
           <select class="form-control" [(ngModel)]="repoFilter" (change)="loadEnrichments()" style="width:200px">
             <option value="">All Repositories</option>
-            <option *ngFor="let r of repos" [value]="r.id">{{ r.name }}</option>
+            @for (r of repos; track r) {
+              <option [value]="r.id">{{ r.name }}</option>
+            }
           </select>
         </div>
       </div>
     </div>
-
-    <div *ngIf="loading" style="display:flex;justify-content:center;padding:2rem"><div class="spinner"></div></div>
-
-    <div *ngIf="!loading && enrichments.length > 0">
-      <div class="card" *ngFor="let e of enrichments" style="margin-bottom:1rem;cursor:pointer" (click)="toggleExpand(e.id)">
-        <div style="display:flex;justify-content:space-between;align-items:flex-start">
-          <div>
-            <div style="margin-bottom:0.375rem">
-              <span class="badge badge-primary">{{ getTypeLabel(e.type) }}</span>
-              <span class="badge badge-muted" style="margin-left:0.25rem">{{ getSubtypeLabel(e.subtype) }}</span>
-              <span class="badge badge-muted" style="margin-left:0.25rem" *ngIf="e.language">{{ e.language }}</span>
-              <span class="badge" style="margin-left:0.25rem" [ngClass]="qualityClass(e.quality)">{{ qualityLabel(e.quality) }}</span>
+    
+    @if (loading) {
+      <div style="display:flex;justify-content:center;padding:2rem"><div class="spinner"></div></div>
+    }
+    
+    @if (!loading && enrichments.length > 0) {
+      <div>
+        @for (e of enrichments; track e) {
+          <div class="card" style="margin-bottom:1rem;cursor:pointer" (click)="toggleExpand(e.id)">
+            <div style="display:flex;justify-content:space-between;align-items:flex-start">
+              <div>
+                <div style="margin-bottom:0.375rem">
+                  <span class="badge badge-primary">{{ getTypeLabel(e.type) }}</span>
+                  <span class="badge badge-muted" style="margin-left:0.25rem">{{ getSubtypeLabel(e.subtype) }}</span>
+                  @if (e.language) {
+                    <span class="badge badge-muted" style="margin-left:0.25rem">{{ e.language }}</span>
+                  }
+                  <span class="badge" style="margin-left:0.25rem" [ngClass]="qualityClass(e.quality)">{{ qualityLabel(e.quality) }}</span>
+                </div>
+                <strong>{{ e.title || e.filePath || 'Untitled' }}</strong>
+                @if (e.filePath || getRepoName(e.repositoryId)) {
+                  <div class="text-muted" style="font-size:var(--font-xs);margin-top:0.25rem">
+                    @if (getRepoName(e.repositoryId)) {
+                      <span>{{ getRepoName(e.repositoryId) }}</span>
+                    }
+                    @if (getRepoName(e.repositoryId) && e.filePath) {
+                      <span> / </span>
+                    }
+                    @if (e.filePath) {
+                      <code>{{ e.filePath }}</code>
+                    }
+                  </div>
+                }
+              </div>
             </div>
-            <strong>{{ e.title || e.filePath || 'Untitled' }}</strong>
-            <div class="text-muted" style="font-size:var(--font-xs);margin-top:0.25rem" *ngIf="e.filePath || getRepoName(e.repositoryId)">
-              <span *ngIf="getRepoName(e.repositoryId)">{{ getRepoName(e.repositoryId) }}</span>
-              <span *ngIf="getRepoName(e.repositoryId) && e.filePath"> / </span>
-              <code *ngIf="e.filePath">{{ e.filePath }}</code>
-            </div>
+            @if (expandedId === e.id) {
+              <div style="margin-top:1rem">
+                <pre><code>{{ e.content }}</code></pre>
+              </div>
+            }
           </div>
-        </div>
-        <div *ngIf="expandedId === e.id" style="margin-top:1rem">
-          <pre><code>{{ e.content }}</code></pre>
-        </div>
+        }
+        @if (totalCount > enrichments.length) {
+          <div style="display:flex;justify-content:center;gap:0.75rem;margin-top:1rem">
+            <button class="btn btn-secondary" (click)="loadMore()">Load More</button>
+          </div>
+        }
       </div>
-      <div style="display:flex;justify-content:center;gap:0.75rem;margin-top:1rem" *ngIf="totalCount > enrichments.length">
-        <button class="btn btn-secondary" (click)="loadMore()">Load More</button>
+    }
+    
+    @if (!loading && enrichments.length === 0) {
+      <div class="empty-state card">
+        <i class="bi bi-file-earmark-text"></i>
+        <h3>No enrichments found</h3>
+        <p>Index a repository to generate enrichments.</p>
       </div>
-    </div>
-
-    <div *ngIf="!loading && enrichments.length === 0" class="empty-state card">
-      <i class="bi bi-file-earmark-text"></i>
-      <h3>No enrichments found</h3>
-      <p>Index a repository to generate enrichments.</p>
-    </div>
-  `
+    }
+    `
 })
 export class EnrichmentBrowserComponent implements OnInit {
   enrichments: Enrichment[] = [];

--- a/client/src/app/components/layout/sidebar.component.ts
+++ b/client/src/app/components/layout/sidebar.component.ts
@@ -1,13 +1,13 @@
 import { Component } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
-import { CommonModule } from '@angular/common';
+
 import { environment } from '../../../environments/environment';
 import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-sidebar',
   standalone: true,
-  imports: [RouterLink, RouterLinkActive, CommonModule],
+  imports: [RouterLink, RouterLinkActive],
   template: `
     <aside class="sidebar">
       <div class="sidebar-brand">
@@ -53,27 +53,33 @@ import { AuthService } from '../../services/auth.service';
         </div>
       </nav>
       <div class="sidebar-footer">
-        <div class="user-section" *ngIf="authService.authEnabled && authService.isAuthenticated()">
-          <div class="user-info">
-            <svg class="user-avatar" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"/>
-            </svg>
-            <div class="user-details">
-              <span class="user-name">{{ authService.getUserName() || 'User' }}</span>
-              <span class="user-email" *ngIf="authService.getUserEmail()">{{ authService.getUserEmail() }}</span>
+        @if (authService.authEnabled && authService.isAuthenticated()) {
+          <div class="user-section">
+            <div class="user-info">
+              <svg class="user-avatar" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"/>
+              </svg>
+              <div class="user-details">
+                <span class="user-name">{{ authService.getUserName() || 'User' }}</span>
+                @if (authService.getUserEmail()) {
+                  <span class="user-email">{{ authService.getUserEmail() }}</span>
+                }
+              </div>
             </div>
+            <button class="btn btn-sm btn-secondary sign-out-btn" (click)="signOut()">
+              <i class="bi bi-box-arrow-right"></i> Sign Out
+            </button>
           </div>
-          <button class="btn btn-sm btn-secondary sign-out-btn" (click)="signOut()">
-            <i class="bi bi-box-arrow-right"></i> Sign Out
-          </button>
-        </div>
-        <div class="dev-indicator" *ngIf="isDevMode && !authService.authEnabled">
-          <span class="dev-dot"></span>
-          <span>Development Mode</span>
-        </div>
+        }
+        @if (isDevMode && !authService.authEnabled) {
+          <div class="dev-indicator">
+            <span class="dev-dot"></span>
+            <span>Development Mode</span>
+          </div>
+        }
       </div>
     </aside>
-  `,
+    `,
   styles: [`
     .sidebar {
       position: fixed; left: 0; top: 0; bottom: 0;

--- a/client/src/app/components/repositories/repository-add.component.ts
+++ b/client/src/app/components/repositories/repository-add.component.ts
@@ -1,13 +1,13 @@
 import { Component } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { CommonModule } from '@angular/common';
+
 import { ApiService } from '../../services/api.service';
 
 @Component({
   selector: 'app-repository-add',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink],
+  imports: [FormsModule, RouterLink],
   template: `
     <div class="page-header">
       <h1>Add Repository</h1>
@@ -17,20 +17,24 @@ import { ApiService } from '../../services/api.service';
         <div class="form-group">
           <label for="url">Repository URL *</label>
           <input id="url" class="form-control" [(ngModel)]="url" name="url"
-                 placeholder="https://github.com/owner/repo" required
-                 (ngModelChange)="onUrlChange()">
+            placeholder="https://github.com/owner/repo" required
+            (ngModelChange)="onUrlChange()">
         </div>
         <div class="form-group">
           <label for="pat">Personal Access Token (optional)</label>
           <input id="pat" type="password" class="form-control" [(ngModel)]="pat" name="pat"
-                 placeholder="For private repositories">
+            placeholder="For private repositories">
         </div>
-        <div class="duplicate-warning" *ngIf="duplicateRepoId">
-          <i class="bi bi-exclamation-triangle"></i>
-          This repository is already being tracked.
-          <a [routerLink]="['/repositories', duplicateRepoId]">View existing repository</a>
-        </div>
-        <div class="error-message" *ngIf="error">{{ error }}</div>
+        @if (duplicateRepoId) {
+          <div class="duplicate-warning">
+            <i class="bi bi-exclamation-triangle"></i>
+            This repository is already being tracked.
+            <a [routerLink]="['/repositories', duplicateRepoId]">View existing repository</a>
+          </div>
+        }
+        @if (error) {
+          <div class="error-message">{{ error }}</div>
+        }
         <div style="display:flex;gap:0.75rem;margin-top:1.5rem">
           <button type="submit" class="btn btn-primary" [disabled]="submitting || !url || !!duplicateRepoId">
             {{ submitting ? 'Adding...' : 'Add Repository' }}
@@ -39,7 +43,7 @@ import { ApiService } from '../../services/api.service';
         </div>
       </form>
     </div>
-  `,
+    `,
   styles: [`
     .error-message { color: var(--danger); margin-top: 0.5rem; padding: 0.75rem; background: rgba(220,53,69,0.1); border-radius: var(--radius); }
     .duplicate-warning { color: #856404; margin-top: 0.5rem; padding: 0.75rem; background: rgba(255,193,7,0.15); border: 1px solid rgba(255,193,7,0.3); border-radius: var(--radius); font-size: var(--font-sm); }

--- a/client/src/app/components/repositories/repository-analytics.component.ts
+++ b/client/src/app/components/repositories/repository-analytics.component.ts
@@ -19,32 +19,38 @@ interface HeatmapCell {
     <!-- Git Activity Heatmap -->
     <div class="card" style="margin-top:1.5rem;padding:1.25rem">
       <h3 style="font-size:1rem;margin-bottom:1rem">Git Activity</h3>
-
-      <div *ngIf="heatmapLoading" style="display:flex;justify-content:center;padding:2rem">
-        <div class="spinner"></div>
-      </div>
-
-      <div *ngIf="!heatmapLoading && heatmapCells.length > 0" class="heatmap-container">
-        <div class="heatmap-scroll">
-          <div class="day-labels">
-            <span></span>
-            <span>Mon</span>
-            <span></span>
-            <span>Wed</span>
-            <span></span>
-            <span>Fri</span>
-            <span></span>
-          </div>
-          <svg [attr.width]="heatmapWidth" [attr.height]="heatmapHeight"
-               style="display:block" role="img" aria-label="Contribution heatmap">
-            <!-- Month labels -->
-            <text *ngFor="let label of monthLabels"
+    
+      @if (heatmapLoading) {
+        <div style="display:flex;justify-content:center;padding:2rem">
+          <div class="spinner"></div>
+        </div>
+      }
+    
+      @if (!heatmapLoading && heatmapCells.length > 0) {
+        <div class="heatmap-container">
+          <div class="heatmap-scroll">
+            <div class="day-labels">
+              <span></span>
+              <span>Mon</span>
+              <span></span>
+              <span>Wed</span>
+              <span></span>
+              <span>Fri</span>
+              <span></span>
+            </div>
+            <svg [attr.width]="heatmapWidth" [attr.height]="heatmapHeight"
+              style="display:block" role="img" aria-label="Contribution heatmap">
+              <!-- Month labels -->
+              @for (label of monthLabels; track label) {
+                <text
                   [attr.x]="label.x" y="10"
                   fill="var(--text-muted)" font-size="10" font-family="inherit">
-              {{ label.text }}
-            </text>
-            <!-- Day cells -->
-            <rect *ngFor="let cell of heatmapCells"
+                  {{ label.text }}
+                </text>
+              }
+              <!-- Day cells -->
+              @for (cell of heatmapCells; track cell) {
+                <rect
                   [attr.x]="cell.col * (cellSize + cellGap)"
                   [attr.y]="18 + cell.row * (cellSize + cellGap)"
                   [attr.width]="cellSize"
@@ -52,112 +58,135 @@ interface HeatmapCell {
                   [attr.fill]="getHeatmapColor(cell.commitCount)"
                   rx="2"
                   style="cursor:default">
-              <title>{{ cell.date }}: {{ cell.commitCount }} commit{{ cell.commitCount !== 1 ? 's' : '' }}</title>
-            </rect>
-          </svg>
+                  <title>{{ cell.date }}: {{ cell.commitCount }} commit{{ cell.commitCount !== 1 ? 's' : '' }}</title>
+                </rect>
+              }
+            </svg>
+          </div>
+          <!-- Legend -->
+          <div class="heatmap-legend">
+            <span class="text-muted" style="font-size:0.75rem">Less</span>
+            <span class="legend-cell" [style.background]="'#ebedf0'"></span>
+            <span class="legend-cell" [style.background]="'#c6e48b'"></span>
+            <span class="legend-cell" [style.background]="'#7bc96f'"></span>
+            <span class="legend-cell" [style.background]="'#239a3b'"></span>
+            <span class="legend-cell" [style.background]="'#196127'"></span>
+            <span class="text-muted" style="font-size:0.75rem">More</span>
+          </div>
         </div>
-
-        <!-- Legend -->
-        <div class="heatmap-legend">
-          <span class="text-muted" style="font-size:0.75rem">Less</span>
-          <span class="legend-cell" [style.background]="'#ebedf0'"></span>
-          <span class="legend-cell" [style.background]="'#c6e48b'"></span>
-          <span class="legend-cell" [style.background]="'#7bc96f'"></span>
-          <span class="legend-cell" [style.background]="'#239a3b'"></span>
-          <span class="legend-cell" [style.background]="'#196127'"></span>
-          <span class="text-muted" style="font-size:0.75rem">More</span>
+      }
+    
+      @if (!heatmapLoading && heatmapCells.length === 0) {
+        <div class="text-muted" style="font-size:0.875rem">
+          No commit activity data available.
         </div>
-      </div>
-
-      <div *ngIf="!heatmapLoading && heatmapCells.length === 0" class="text-muted" style="font-size:0.875rem">
-        No commit activity data available.
-      </div>
-
+      }
+    
       <!-- Stats -->
-      <div *ngIf="heatmapStats" class="heatmap-stats">
-        <div class="stat-item">
-          <span class="stat-value">{{ heatmapStats.totalCommits }}</span>
-          <span class="stat-label">Total commits</span>
+      @if (heatmapStats) {
+        <div class="heatmap-stats">
+          <div class="stat-item">
+            <span class="stat-value">{{ heatmapStats.totalCommits }}</span>
+            <span class="stat-label">Total commits</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-value">{{ heatmapStats.uniqueAuthors }}</span>
+            <span class="stat-label">Contributors</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-value">{{ heatmapStats.avgPerDay | number:'1.1-1' }}</span>
+            <span class="stat-label">Avg/day</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-value">{{ heatmapStats.maxCommitsInDay }}</span>
+            <span class="stat-label">Max in a day</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-value">{{ heatmapStats.mostActiveDay }}</span>
+            <span class="stat-label">Most active day</span>
+          </div>
+          @if (heatmapStats.longestInactiveStreak > 0) {
+            <div class="stat-item">
+              <span class="stat-value">{{ heatmapStats.longestInactiveStreak }}d</span>
+              <span class="stat-label">Longest streak</span>
+            </div>
+          }
         </div>
-        <div class="stat-item">
-          <span class="stat-value">{{ heatmapStats.uniqueAuthors }}</span>
-          <span class="stat-label">Contributors</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-value">{{ heatmapStats.avgPerDay | number:'1.1-1' }}</span>
-          <span class="stat-label">Avg/day</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-value">{{ heatmapStats.maxCommitsInDay }}</span>
-          <span class="stat-label">Max in a day</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-value">{{ heatmapStats.mostActiveDay }}</span>
-          <span class="stat-label">Most active day</span>
-        </div>
-        <div class="stat-item" *ngIf="heatmapStats.longestInactiveStreak > 0">
-          <span class="stat-value">{{ heatmapStats.longestInactiveStreak }}d</span>
-          <span class="stat-label">Longest streak</span>
-        </div>
-      </div>
+      }
     </div>
-
+    
     <div style="display:grid;grid-template-columns:1fr 1fr;gap:1.5rem;margin-top:1.5rem">
       <!-- Language Breakdown -->
-      <div class="card" *ngIf="languages.length > 0">
-        <h3 style="font-size:1rem;margin-bottom:1rem">Languages</h3>
-        <div class="bar-chart">
-          <div class="bar-row" *ngFor="let lang of languages">
-            <span class="bar-label">{{ lang.language }}</span>
-            <div class="bar-track">
-              <div class="bar-fill" [style.width.%]="(lang.count / maxLangCount) * 100"></div>
-            </div>
-            <span class="bar-value">{{ lang.count }}</span>
+      @if (languages.length > 0) {
+        <div class="card">
+          <h3 style="font-size:1rem;margin-bottom:1rem">Languages</h3>
+          <div class="bar-chart">
+            @for (lang of languages; track lang) {
+              <div class="bar-row">
+                <span class="bar-label">{{ lang.language }}</span>
+                <div class="bar-track">
+                  <div class="bar-fill" [style.width.%]="(lang.count / maxLangCount) * 100"></div>
+                </div>
+                <span class="bar-value">{{ lang.count }}</span>
+              </div>
+            }
           </div>
         </div>
-      </div>
-
+      }
+    
       <!-- File Types -->
-      <div class="card" *ngIf="fileTypes.length > 0">
-        <h3 style="font-size:1rem;margin-bottom:1rem">File Types</h3>
-        <div class="bar-chart">
-          <div class="bar-row" *ngFor="let ft of fileTypes.slice(0, 10)">
-            <span class="bar-label">{{ ft.extension }}</span>
-            <div class="bar-track">
-              <div class="bar-fill" [style.width.%]="(ft.count / maxFileTypeCount) * 100" style="background:var(--accent)"></div>
-            </div>
-            <span class="bar-value">{{ ft.count }}</span>
+      @if (fileTypes.length > 0) {
+        <div class="card">
+          <h3 style="font-size:1rem;margin-bottom:1rem">File Types</h3>
+          <div class="bar-chart">
+            @for (ft of fileTypes.slice(0, 10); track ft) {
+              <div class="bar-row">
+                <span class="bar-label">{{ ft.extension }}</span>
+                <div class="bar-track">
+                  <div class="bar-fill" [style.width.%]="(ft.count / maxFileTypeCount) * 100" style="background:var(--accent)"></div>
+                </div>
+                <span class="bar-value">{{ ft.count }}</span>
+              </div>
+            }
           </div>
         </div>
-      </div>
-
+      }
+    
       <!-- Top Terms -->
-      <div class="card" *ngIf="topTerms.length > 0">
-        <h3 style="font-size:1rem;margin-bottom:1rem">Top Terms</h3>
-        <div class="term-cloud">
-          <span *ngFor="let term of topTerms" class="term-tag"
+      @if (topTerms.length > 0) {
+        <div class="card">
+          <h3 style="font-size:1rem;margin-bottom:1rem">Top Terms</h3>
+          <div class="term-cloud">
+            @for (term of topTerms; track term) {
+              <span class="term-tag"
                 [style.fontSize.rem]="0.7 + (term.count / maxTermCount) * 0.8"
                 [style.opacity]="0.5 + (term.count / maxTermCount) * 0.5">
-            {{ term.term }}
-          </span>
-        </div>
-      </div>
-
-      <!-- Complex Files -->
-      <div class="card" *ngIf="complexFiles.length > 0">
-        <h3 style="font-size:1rem;margin-bottom:1rem">Largest Files (by chunks)</h3>
-        <div class="bar-chart">
-          <div class="bar-row" *ngFor="let f of complexFiles">
-            <span class="bar-label" style="font-size:0.75rem" [title]="f.filePath">{{ shortPath(f.filePath) }}</span>
-            <div class="bar-track">
-              <div class="bar-fill" [style.width.%]="(f.chunkCount / maxChunkCount) * 100" style="background:var(--accent-secondary)"></div>
-            </div>
-            <span class="bar-value">{{ f.chunkCount }}</span>
+                {{ term.term }}
+              </span>
+            }
           </div>
         </div>
-      </div>
+      }
+    
+      <!-- Complex Files -->
+      @if (complexFiles.length > 0) {
+        <div class="card">
+          <h3 style="font-size:1rem;margin-bottom:1rem">Largest Files (by chunks)</h3>
+          <div class="bar-chart">
+            @for (f of complexFiles; track f) {
+              <div class="bar-row">
+                <span class="bar-label" style="font-size:0.75rem" [title]="f.filePath">{{ shortPath(f.filePath) }}</span>
+                <div class="bar-track">
+                  <div class="bar-fill" [style.width.%]="(f.chunkCount / maxChunkCount) * 100" style="background:var(--accent-secondary)"></div>
+                </div>
+                <span class="bar-value">{{ f.chunkCount }}</span>
+              </div>
+            }
+          </div>
+        </div>
+      }
     </div>
-  `,
+    `,
   styles: [`
     .bar-chart { display: flex; flex-direction: column; gap: 0.5rem; }
     .bar-row { display: flex; align-items: center; gap: 0.5rem; }

--- a/client/src/app/components/repositories/repository-detail.component.ts
+++ b/client/src/app/components/repositories/repository-detail.component.ts
@@ -34,872 +34,1033 @@ interface CommitComparison {
   standalone: true,
   imports: [CommonModule, FormsModule, RouterLink, RepositoryHistoryComponent, RepositoryAnalyticsComponent],
   template: `
-    <div *ngIf="loading" style="display:flex;justify-content:center;padding:3rem"><div class="spinner"></div></div>
-
-    <div *ngIf="!loading && repo">
-      <div class="page-header">
-        <div>
-          <h1>{{ repo.name }}</h1>
-          <div style="display:flex;gap:0.75rem;align-items:center;margin-top:0.25rem" *ngIf="repo.lastIndexedCommitSha || repo.defaultBranch">
-            <span *ngIf="repo.defaultBranch" class="badge badge-primary" style="font-size:0.75rem">
-              <i class="bi bi-diagram-2"></i> {{ repo.defaultBranch }}
-            </span>
-            <code *ngIf="repo.lastIndexedCommitSha" style="font-size:0.75rem;color:var(--text-muted)">
-              {{ repo.lastIndexedCommitSha.substring(0, 7) }}
-            </code>
+    @if (loading) {
+      <div style="display:flex;justify-content:center;padding:3rem"><div class="spinner"></div></div>
+    }
+    
+    @if (!loading && repo) {
+      <div>
+        <div class="page-header">
+          <div>
+            <h1>{{ repo.name }}</h1>
+            @if (repo.lastIndexedCommitSha || repo.defaultBranch) {
+              <div style="display:flex;gap:0.75rem;align-items:center;margin-top:0.25rem">
+                @if (repo.defaultBranch) {
+                  <span class="badge badge-primary" style="font-size:0.75rem">
+                    <i class="bi bi-diagram-2"></i> {{ repo.defaultBranch }}
+                  </span>
+                }
+                @if (repo.lastIndexedCommitSha) {
+                  <code style="font-size:0.75rem;color:var(--text-muted)">
+                    {{ repo.lastIndexedCommitSha.substring(0, 7) }}
+                  </code>
+                }
+              </div>
+            }
+          </div>
+          <div style="display:flex;gap:0.75rem">
+            <button class="btn btn-secondary" (click)="sync()" [disabled]="syncing">
+              <i class="bi bi-arrow-repeat"></i> {{ syncing ? 'Syncing...' : 'Sync' }}
+            </button>
+            @if (syncMessage) {
+              <span style="color:var(--success);font-size:0.85rem;align-self:center">{{ syncMessage }}</span>
+            }
+            @if (syncError) {
+              <span style="color:var(--danger);font-size:0.85rem;align-self:center">{{ syncError }}</span>
+            }
+            <button class="btn btn-secondary" style="color:var(--danger);border-color:var(--danger)" (click)="wipeEnrichments()">
+              <i class="bi bi-eraser"></i> Wipe Enrichments
+            </button>
+            <button class="btn btn-danger" (click)="confirmDelete()">
+              <i class="bi bi-trash"></i> Delete
+            </button>
           </div>
         </div>
-        <div style="display:flex;gap:0.75rem">
-          <button class="btn btn-secondary" (click)="sync()" [disabled]="syncing">
-            <i class="bi bi-arrow-repeat"></i> {{ syncing ? 'Syncing...' : 'Sync' }}
-          </button>
-          <span *ngIf="syncMessage" style="color:var(--success);font-size:0.85rem;align-self:center">{{ syncMessage }}</span>
-          <span *ngIf="syncError" style="color:var(--danger);font-size:0.85rem;align-self:center">{{ syncError }}</span>
-          <button class="btn btn-secondary" style="color:var(--danger);border-color:var(--danger)" (click)="wipeEnrichments()">
-            <i class="bi bi-eraser"></i> Wipe Enrichments
-          </button>
-          <button class="btn btn-danger" (click)="confirmDelete()">
-            <i class="bi bi-trash"></i> Delete
-          </button>
+        <!-- Tab Navigation -->
+        <div style="display:flex;gap:0;border-bottom:2px solid var(--border);margin-bottom:1.5rem;align-items:center">
+          @for (tab of ['Overview', 'Insights', 'Report', 'History', 'Analytics']; track tab) {
+            <button
+              (click)="activeTab = tab"
+              [style.border-bottom]="activeTab === tab ? '2px solid var(--primary)' : '2px solid transparent'"
+              style="padding:0.75rem 1.25rem;background:none;border:none;border-bottom:2px solid transparent;cursor:pointer;font-size:var(--font-sm);font-weight:500;color:var(--text-muted);margin-bottom:-2px;transition:all 0.15s"
+              [style.color]="activeTab === tab ? 'var(--primary)' : 'var(--text-muted)'">
+              {{ tab }}
+            </button>
+          }
+          <div style="margin-left:auto;margin-bottom:-2px;padding:0.375rem 0">
+            <select [(ngModel)]="selectedRef" (ngModelChange)="onRefChange($event)"
+              style="padding:0.375rem 0.625rem;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);color:var(--text);font-size:0.8125rem;min-width:160px"
+              title="Filter by branch or tag">
+              <option value="">All branches</option>
+              @if (repo.branches && repo.branches.length > 0) {
+                <optgroup label="Branches">
+                  @for (b of repo.branches; track b) {
+                    <option [value]="b.name">{{ b.name }}{{ b.isDefault ? ' (default)' : '' }}</option>
+                  }
+                </optgroup>
+              }
+              @if (repo.tags && repo.tags.length > 0) {
+                <optgroup label="Tags">
+                  @for (t of repo.tags; track t) {
+                    <option [value]="t.name">{{ t.name }}</option>
+                  }
+                </optgroup>
+              }
+            </select>
+          </div>
         </div>
-      </div>
-
-      <!-- Tab Navigation -->
-      <div style="display:flex;gap:0;border-bottom:2px solid var(--border);margin-bottom:1.5rem;align-items:center">
-        <button *ngFor="let tab of ['Overview', 'Insights', 'Report', 'History', 'Analytics']"
-                (click)="activeTab = tab"
-                [style.border-bottom]="activeTab === tab ? '2px solid var(--primary)' : '2px solid transparent'"
-                style="padding:0.75rem 1.25rem;background:none;border:none;border-bottom:2px solid transparent;cursor:pointer;font-size:var(--font-sm);font-weight:500;color:var(--text-muted);margin-bottom:-2px;transition:all 0.15s"
-                [style.color]="activeTab === tab ? 'var(--primary)' : 'var(--text-muted)'">
-          {{ tab }}
-        </button>
-        <div style="margin-left:auto;margin-bottom:-2px;padding:0.375rem 0">
-          <select [(ngModel)]="selectedRef" (ngModelChange)="onRefChange($event)"
-                  style="padding:0.375rem 0.625rem;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);color:var(--text);font-size:0.8125rem;min-width:160px"
-                  title="Filter by branch or tag">
-            <option value="">All branches</option>
-            <optgroup label="Branches" *ngIf="repo.branches && repo.branches.length > 0">
-              <option *ngFor="let b of repo.branches" [value]="b.name">{{ b.name }}{{ b.isDefault ? ' (default)' : '' }}</option>
-            </optgroup>
-            <optgroup label="Tags" *ngIf="repo.tags && repo.tags.length > 0">
-              <option *ngFor="let t of repo.tags" [value]="t.name">{{ t.name }}</option>
-            </optgroup>
-          </select>
-        </div>
-      </div>
-
-      <!-- Overview Tab -->
-      <div *ngIf="activeTab === 'Overview'">
-      <div style="display:grid;grid-template-columns:1fr 1fr;gap:1.5rem;margin-bottom:1.5rem">
-        <div class="card">
-          <h3 style="margin-bottom:1rem;font-size:1rem">Details</h3>
-          <div class="detail-row"><span class="label">URL</span><a [href]="repo.url" target="_blank">{{ repo.url }}</a></div>
-          <div class="detail-row"><span class="label">Provider</span><span class="badge badge-muted">{{ repo.provider }}</span></div>
-          <div class="detail-row"><span class="label">Status</span><span class="badge" [ngClass]="statusClass(repo.status)">{{ repo.status }}</span></div>
-          <div class="detail-row"><span class="label">Default Branch</span><span>{{ repo.defaultBranch || '—' }}</span></div>
-          <div class="detail-row"><span class="label">Last Synced</span><span>{{ repo.lastSyncedAt ? (repo.lastSyncedAt | date:'medium') : 'Never' }}</span></div>
-          <div class="detail-row">
-            <span class="label">Sync Interval</span>
-            <select [ngModel]="syncIntervalValue" (ngModelChange)="onSyncIntervalChange($event)"
+        <!-- Overview Tab -->
+        @if (activeTab === 'Overview') {
+          <div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:1.5rem;margin-bottom:1.5rem">
+              <div class="card">
+                <h3 style="margin-bottom:1rem;font-size:1rem">Details</h3>
+                <div class="detail-row"><span class="label">URL</span><a [href]="repo.url" target="_blank">{{ repo.url }}</a></div>
+                <div class="detail-row"><span class="label">Provider</span><span class="badge badge-muted">{{ repo.provider }}</span></div>
+                <div class="detail-row"><span class="label">Status</span><span class="badge" [ngClass]="statusClass(repo.status)">{{ repo.status }}</span></div>
+                <div class="detail-row"><span class="label">Default Branch</span><span>{{ repo.defaultBranch || '—' }}</span></div>
+                <div class="detail-row"><span class="label">Last Synced</span><span>{{ repo.lastSyncedAt ? (repo.lastSyncedAt | date:'medium') : 'Never' }}</span></div>
+                <div class="detail-row">
+                  <span class="label">Sync Interval</span>
+                  <select [ngModel]="syncIntervalValue" (ngModelChange)="onSyncIntervalChange($event)"
                     style="padding:0.375rem 0.5rem;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);color:var(--text);font-size:0.8125rem">
-              <option value="null">Default</option>
-              <option value="0">Manual Only</option>
-              <option value="15">15 min</option>
-              <option value="30">30 min</option>
-              <option value="60">1 hour</option>
-              <option value="120">2 hours</option>
-              <option value="360">6 hours</option>
-              <option value="720">12 hours</option>
-              <option value="1440">Daily</option>
-            </select>
-            <span *ngIf="syncIntervalSaving" style="margin-left:0.5rem;font-size:0.75rem;color:var(--text-muted)">Saving...</span>
-            <span *ngIf="syncIntervalSaved" style="margin-left:0.5rem;font-size:0.75rem;color:var(--success)">Saved</span>
-          </div>
-        </div>
-        <div class="card" *ngIf="repo.stats">
-          <h3 style="margin-bottom:1rem;font-size:1rem">Statistics</h3>
-          <div class="stat-grid">
-            <div class="stat"><div class="stat-value">{{ repo.stats.commitCount }}</div><div class="stat-label">Commits</div></div>
-            <div class="stat">
-              <div class="stat-value">{{ repo.stats.enrichmentCount }}</div>
-              <div class="stat-label">Enrichments</div>
-              <div class="stat-sub" *ngIf="repo.stats.storageSizeBytes > 0" style="font-size:var(--font-xs);color:var(--text-muted);margin-top:0.125rem">{{ formatBytes(repo.stats.storageSizeBytes) }}</div>
-            </div>
-            <div class="stat">
-              <div class="stat-value" [style.color]="repo.stats.hasEmbeddings ? 'var(--primary)' : 'var(--text-muted)'">
-                {{ repo.stats.embeddingCount }}
-              </div>
-              <div class="stat-label">Embeddings</div>
-            </div>
-            <div class="stat"><div class="stat-value">{{ repo.stats.pendingTaskCount }}</div><div class="stat-label">Pending Tasks</div></div>
-          </div>
-          <div *ngIf="!repo.stats.hasEmbeddings && repo.status === 'indexed'"
-               style="margin-top:0.75rem;padding:0.5rem 0.75rem;background:rgba(255,193,7,0.08);border-radius:var(--radius);font-size:0.8125rem;color:#856404">
-            <i class="bi bi-info-circle"></i> No embeddings -- semantic search unavailable. Configure an embedding API key in Settings.
-          </div>
-        </div>
-      </div>
-
-      <!-- Summary stats from analytics endpoint -->
-      <div style="display:grid;grid-template-columns:1fr 1fr;gap:1.5rem;margin-bottom:1.5rem" *ngIf="summary">
-        <div class="card">
-          <h3 style="margin-bottom:1rem;font-size:1rem">Last Commit</h3>
-          <div *ngIf="summary.lastCommit">
-            <div style="font-weight:500;margin-bottom:0.25rem">{{ summary.lastCommit.authorName }}</div>
-            <div class="text-muted" style="font-size:0.8125rem;margin-bottom:0.5rem">{{ summary.lastCommit.authorEmail }}</div>
-            <div style="font-size:0.875rem;margin-bottom:0.5rem">{{ summary.lastCommit.message }}</div>
-            <div class="text-muted" style="font-size:0.8125rem">
-              <code>{{ summary.lastCommit.sha?.substring(0, 8) }}</code>
-              <span style="margin-left:0.5rem">{{ getRelativeTime(summary.lastCommit.committedAt) }}</span>
-            </div>
-          </div>
-          <div *ngIf="!summary.lastCommit" class="text-muted">No commits found</div>
-        </div>
-        <div class="card">
-          <h3 style="margin-bottom:1rem;font-size:1rem">File Breakdown</h3>
-          <div class="stat-grid" style="grid-template-columns:repeat(3, 1fr)">
-            <div class="stat"><div class="stat-value">{{ summary.stats.totalFiles }}</div><div class="stat-label">Total Files</div></div>
-            <div class="stat"><div class="stat-value">{{ summary.stats.testFiles }}</div><div class="stat-label">Test Files</div></div>
-            <div class="stat"><div class="stat-value">{{ summary.stats.apiDocs }}</div><div class="stat-label">API Docs</div></div>
-          </div>
-          <div *ngIf="summary.enrichmentsByType && summary.enrichmentsByType.length > 0" style="margin-top:1rem">
-            <div class="text-muted" style="font-size:0.75rem;margin-bottom:0.5rem;font-weight:500;text-transform:uppercase;letter-spacing:0.05em">Enrichments by type</div>
-            <div style="display:flex;flex-wrap:wrap;gap:0.375rem">
-              <span *ngFor="let et of summary.enrichmentsByType" class="badge badge-muted">{{ et.subtype }} ({{ et.count }})</span>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="card" *ngIf="repo.branches && repo.branches.length > 0">
-        <h3 style="margin-bottom:1rem;font-size:1rem">Branches</h3>
-        <div class="tag-list">
-          <span *ngFor="let branch of repo.branches" class="badge" [ngClass]="branch.isDefault ? 'badge-primary' : 'badge-muted'">
-            {{ branch.name }}
-          </span>
-        </div>
-      </div>
-
-      <!-- Commit Comparison -->
-      <div class="card" style="margin-top:1.5rem" *ngIf="commits.length >= 2">
-        <h3 style="margin-bottom:1rem;font-size:1rem">Compare Commits</h3>
-        <div style="display:flex;gap:0.75rem;align-items:flex-end;flex-wrap:wrap">
-          <div>
-            <label style="font-size:0.75rem;color:var(--text-muted);display:block;margin-bottom:0.25rem">From</label>
-            <select [(ngModel)]="compareFrom" style="padding:0.375rem 0.5rem;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);color:var(--text);font-size:0.8125rem;min-width:200px">
-              <option value="">Select commit...</option>
-              <option *ngFor="let c of commits" [value]="c.sha">{{ c.sha.substring(0, 7) }} - {{ c.message | slice:0:40 }}</option>
-            </select>
-          </div>
-          <div>
-            <label style="font-size:0.75rem;color:var(--text-muted);display:block;margin-bottom:0.25rem">To</label>
-            <select [(ngModel)]="compareTo" style="padding:0.375rem 0.5rem;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);color:var(--text);font-size:0.8125rem;min-width:200px">
-              <option value="">Select commit...</option>
-              <option *ngFor="let c of commits" [value]="c.sha">{{ c.sha.substring(0, 7) }} - {{ c.message | slice:0:40 }}</option>
-            </select>
-          </div>
-          <button class="btn btn-primary" (click)="compareCommits()" [disabled]="!compareFrom || !compareTo || comparing" style="font-size:0.8125rem">
-            <i class="bi bi-arrow-left-right"></i> Compare
-          </button>
-        </div>
-        <div *ngIf="compareError" style="margin-top:0.75rem;color:var(--danger);font-size:0.8125rem">{{ compareError }}</div>
-
-        <!-- Comparison Results -->
-        <div *ngIf="comparison" style="margin-top:1rem">
-          <div style="display:flex;gap:1rem;margin-bottom:1rem">
-            <span class="stat-badge added" style="cursor:pointer" (click)="toggleSection('added')">+ {{ comparison.added.length }} added</span>
-            <span class="stat-badge deleted" style="cursor:pointer" (click)="toggleSection('removed')">- {{ comparison.removed.length }} removed</span>
-            <span class="stat-badge updated" style="cursor:pointer" (click)="toggleSection('changed')">~ {{ comparison.changed.length }} changed</span>
-          </div>
-
-          <div *ngIf="expandedSection === 'added' && comparison.added.length > 0" style="margin-top:0.75rem">
-            <h4 style="font-size:0.875rem;margin-bottom:0.5rem;color:var(--success)">Added Enrichments</h4>
-            <div *ngFor="let e of comparison.added" class="compare-item">
-              <div style="font-weight:500;font-size:0.8125rem">{{ e.filePath || '(no file)' }}</div>
-              <span class="badge badge-muted" style="font-size:0.6875rem">{{ e.subtype }}</span>
-              <div class="text-muted" style="font-size:0.75rem;margin-top:0.25rem;white-space:pre-wrap;max-height:4rem;overflow:hidden">{{ e.content | slice:0:200 }}</div>
-            </div>
-          </div>
-
-          <div *ngIf="expandedSection === 'removed' && comparison.removed.length > 0" style="margin-top:0.75rem">
-            <h4 style="font-size:0.875rem;margin-bottom:0.5rem;color:var(--danger)">Removed Enrichments</h4>
-            <div *ngFor="let e of comparison.removed" class="compare-item">
-              <div style="font-weight:500;font-size:0.8125rem">{{ e.filePath || '(no file)' }}</div>
-              <span class="badge badge-muted" style="font-size:0.6875rem">{{ e.subtype }}</span>
-              <div class="text-muted" style="font-size:0.75rem;margin-top:0.25rem;white-space:pre-wrap;max-height:4rem;overflow:hidden">{{ e.content | slice:0:200 }}</div>
-            </div>
-          </div>
-
-          <div *ngIf="expandedSection === 'changed' && comparison.changed.length > 0" style="margin-top:0.75rem">
-            <h4 style="font-size:0.875rem;margin-bottom:0.5rem;color:var(--accent)">Changed Enrichments</h4>
-            <div *ngFor="let c of comparison.changed" class="compare-item">
-              <div style="font-weight:500;font-size:0.8125rem">{{ c.to.filePath || '(no file)' }}</div>
-              <span class="badge badge-muted" style="font-size:0.6875rem">{{ c.to.subtype }}</span>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      </div><!-- End Overview Tab -->
-
-      <!-- Insights Tab -->
-      <div *ngIf="activeTab === 'Insights'" class="insights-tab">
-
-        <!-- Toolbar -->
-        <div class="insights-toolbar">
-          <div class="insights-toolbar-left">
-            <i class="bi bi-journal-richtext" style="font-size:1.125rem;color:var(--primary)"></i>
-            <span style="font-weight:600;font-size:var(--font-sm)">Repository Insights Report</span>
-            <span *ngIf="insightLayers.length > 0 && insightLayers[0].createdAt" class="text-muted" style="font-size:var(--font-xs);margin-left:0.75rem">
-              Generated {{ getRelativeTime(insightLayers[0].createdAt || insightLayers[0].CreatedAt) }}
-            </span>
-          </div>
-          <div class="insights-toolbar-right">
-            <button class="btn btn-secondary btn-sm" (click)="generateInsights()" [disabled]="generatingInsights">
-              <i class="bi bi-lightbulb"></i> {{ generatingInsights ? 'Generating (' + insightLayers.length + '/11)...' : (insightLayers.length > 0 ? 'Regenerate' : 'Generate Insights') }}
-            </button>
-            <span *ngIf="generatingInsights && insightsProgressMessage" class="insights-progress-label" style="font-size:var(--font-xs);color:var(--text-light);margin-left:0.5rem;white-space:nowrap">
-              {{ insightsProgressMessage }}
-            </span>
-            <button class="btn btn-secondary btn-sm" (click)="generateReport()" [disabled]="generatingReport || !insightLayers.length">
-              <i class="bi bi-file-earmark-bar-graph"></i> {{ generatingReport ? 'Generating...' : 'Generate Report' }}
-            </button>
-            <button *ngIf="insightLayers.length > 0" (click)="exportHtml()" class="btn btn-secondary btn-sm">
-              <i class="bi bi-download"></i> Export HTML
-            </button>
-            <button *ngIf="insightLayers.length > 0" class="btn btn-secondary btn-sm" (click)="printReport()">
-              <i class="bi bi-printer"></i> Print
-            </button>
-          </div>
-        </div>
-
-        <!-- Progress Bar -->
-        <div *ngIf="generatingInsights" class="insights-progress-bar-container" style="padding:0 1rem 0.5rem 1rem">
-          <div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.25rem">
-            <div style="flex:1;height:6px;background:var(--border);border-radius:3px;overflow:hidden">
-              <div [style.width.%]="insightsProgress" style="height:100%;background:var(--primary);border-radius:3px;transition:width 0.5s ease"></div>
-            </div>
-            <span style="font-size:var(--font-xs);color:var(--text-light);min-width:2.5rem;text-align:right">{{ insightsProgress }}%</span>
-          </div>
-        </div>
-
-        <!-- Empty State -->
-        <div *ngIf="insightLayers.length === 0 && !generatingInsights" class="insights-empty card">
-          <i class="bi bi-lightbulb" style="font-size:2.5rem;color:var(--text-light);margin-bottom:1rem;display:block"></i>
-          <h3 style="font-size:var(--font-lg);margin-bottom:0.5rem">No insights yet</h3>
-          <p class="text-muted" style="font-size:var(--font-xs);margin-bottom:1.25rem">Click "Generate Insights" to analyze this repository and produce a comprehensive report.</p>
-          <button class="btn btn-primary" (click)="generateInsights()" [disabled]="generatingInsights">
-            <i class="bi bi-lightbulb"></i> Generate Insights
-          </button>
-        </div>
-
-        <!-- Report Document -->
-        <div *ngIf="insightLayers.length > 0" class="insights-document-wrapper" id="insightsDocumentWrapper">
-
-          <!-- TOC Sidebar -->
-          <nav class="insights-toc" id="insightsToc">
-            <div class="insights-toc-title">Contents</div>
-            <a *ngIf="reportData" class="insights-toc-item"
-               [class.active]="activeTocSection === 'report-summary'"
-               (click)="scrollToSection('report-summary', $event)">
-              <i class="bi bi-speedometer2"></i> Summary
-            </a>
-            <a *ngFor="let layer of insightLayers; let i = index"
-               class="insights-toc-item"
-               [class.active]="activeTocSection === 'layer-' + layer.subtype"
-               (click)="scrollToSection('layer-' + layer.subtype, $event)">
-              <span class="insights-toc-num">{{ i + 1 }}</span>
-              {{ getInsightLabel(layer.subtype) }}
-              <span *ngIf="getLayerRating(layer.subtype) as rating" class="insights-toc-rating">
-                {{ getStarRating(rating) }}
-              </span>
-            </a>
-            <a class="insights-toc-item"
-               [class.active]="activeTocSection === 'insights-methodology'"
-               (click)="scrollToSection('insights-methodology', $event)">
-              <i class="bi bi-info-circle"></i> Methodology
-            </a>
-          </nav>
-
-          <!-- Content Area -->
-          <div class="insights-content-area" id="insightsContentArea" (scroll)="onInsightsScroll($event)">
-
-            <!-- Tech Stack Summary Bar -->
-            <div *ngIf="techStackSummary?.length" style="display:flex;flex-wrap:wrap;gap:0.5rem;margin-bottom:1.5rem">
-              <span *ngFor="let tech of techStackSummary" class="badge badge-primary" style="font-size:var(--font-xs)">{{ tech }}</span>
-            </div>
-
-            <!-- Health Score Header -->
-            <div class="insights-section" id="report-summary">
-
-              <!-- No report yet -->
-              <div *ngIf="!reportData" style="text-align:center;padding:1.5rem;background:var(--background-alt);border-radius:var(--radius-lg);margin-bottom:1.5rem">
-                <div style="font-size:var(--font-sm);color:var(--text-muted);margin-bottom:0.75rem">
-                  <i class="bi bi-bar-chart"></i> Health score and ratings available after generating a report.
+                    <option value="null">Default</option>
+                    <option value="0">Manual Only</option>
+                    <option value="15">15 min</option>
+                    <option value="30">30 min</option>
+                    <option value="60">1 hour</option>
+                    <option value="120">2 hours</option>
+                    <option value="360">6 hours</option>
+                    <option value="720">12 hours</option>
+                    <option value="1440">Daily</option>
+                  </select>
+                  @if (syncIntervalSaving) {
+                    <span style="margin-left:0.5rem;font-size:0.75rem;color:var(--text-muted)">Saving...</span>
+                  }
+                  @if (syncIntervalSaved) {
+                    <span style="margin-left:0.5rem;font-size:0.75rem;color:var(--success)">Saved</span>
+                  }
                 </div>
-                <button class="btn btn-secondary btn-sm" (click)="activeTab = 'Report'" style="font-size:var(--font-xs)">
-                  Go to Report tab to generate
-                </button>
               </div>
-
-              <div *ngIf="reportData">
-              <div class="insights-health-header">
-                <div class="insights-health-score"
-                     [style.borderColor]="reportData.overallHealthScore >= 70 ? 'var(--success)' : reportData.overallHealthScore >= 40 ? '#e6a700' : 'var(--danger)'">
-                  <div class="insights-health-number"
-                       [style.color]="reportData.overallHealthScore >= 70 ? 'var(--success)' : reportData.overallHealthScore >= 40 ? '#e6a700' : 'var(--danger)'">
-                    {{ reportData.overallHealthScore }}
-                  </div>
-                  <div class="insights-health-label">Health Score</div>
-                  <div class="insights-health-stars" *ngIf="reportData.overallHealthScore != null">
-                    {{ getStarRating(Math.round(reportData.overallHealthScore / 20)) }}
-                  </div>
-                  <span class="report-info-icon report-info-below" data-tooltip="Weighted average: Maturity (40%) + Quality (40%) + (5 - Risk)/5 (20%). Scale 0-100." style="margin-top:0.25rem"><i class="bi bi-info-circle"></i></span>
-                </div>
-
-                <div class="insights-health-details">
-                  <!-- Star Ratings Summary -->
-                  <div class="insights-ratings-summary" *ngIf="reportData.layers?.length">
-                    <div *ngFor="let lr of reportData.layers" class="insights-rating-row">
-                      <span class="insights-rating-label">{{ getInsightLabel(lr.subtype) }}</span>
-                      <span class="insights-rating-stars">{{ getStarRating(lr.qualityRating) }}</span>
-                      <span class="insights-rating-value">{{ lr.qualityRating }}/5</span>
+              @if (repo.stats) {
+                <div class="card">
+                  <h3 style="margin-bottom:1rem;font-size:1rem">Statistics</h3>
+                  <div class="stat-grid">
+                    <div class="stat"><div class="stat-value">{{ repo.stats.commitCount }}</div><div class="stat-label">Commits</div></div>
+                    <div class="stat">
+                      <div class="stat-value">{{ repo.stats.enrichmentCount }}</div>
+                      <div class="stat-label">Enrichments</div>
+                      @if (repo.stats.storageSizeBytes > 0) {
+                        <div class="stat-sub" style="font-size:var(--font-xs);color:var(--text-muted);margin-top:0.125rem">{{ formatBytes(repo.stats.storageSizeBytes) }}</div>
+                      }
                     </div>
-                  </div>
-                </div>
-              </div>
-
-              <!-- Velocity Metrics -->
-              <div *ngIf="reportData.velocity" class="insights-velocity-row">
-                <div class="insights-velocity-item">
-                  <div class="insights-velocity-value">{{ reportData.velocity.commitsPerMonth }}</div>
-                  <div class="insights-velocity-label">Commits/Month</div>
-                  <span class="report-info-icon report-info-below" data-tooltip="Total commits divided by the repository's active period in months." style="margin-top:0.25rem"><i class="bi bi-info-circle"></i></span>
-                </div>
-                <div class="insights-velocity-item">
-                  <div class="insights-velocity-value">{{ reportData.velocity.activeContributors }}</div>
-                  <div class="insights-velocity-label">Contributors</div>
-                  <span class="report-info-icon report-info-below" data-tooltip="Unique committer emails across all indexed commits." style="margin-top:0.25rem"><i class="bi bi-info-circle"></i></span>
-                </div>
-                <div class="insights-velocity-item">
-                  <div class="insights-velocity-value" style="text-transform:capitalize">{{ reportData.velocity.trend }}</div>
-                  <div class="insights-velocity-label">Trend</div>
-                  <span class="report-info-icon report-info-below" data-tooltip="Compares commit rate in the second half vs first half. Increasing if >20% higher, decreasing if >20% lower." style="margin-top:0.25rem"><i class="bi bi-info-circle"></i></span>
-                </div>
-              </div>
-
-              <!-- Top Contributors -->
-              <div *ngIf="reportData.velocity?.topContributors?.length" style="margin-bottom:1.5rem;padding:0 0.5rem">
-                <div style="font-weight:600;font-size:var(--font-xs);margin-bottom:0.5rem;color:var(--text-muted)">Top Contributors</div>
-                <div style="display:flex;flex-wrap:wrap;gap:0.5rem">
-                  <span *ngFor="let c of reportData.velocity.topContributors" style="display:inline-flex;align-items:center;gap:0.375rem;padding:0.25rem 0.625rem;background:var(--background-alt);border-radius:100px;font-size:var(--font-xs)">
-                    <strong>{{ c.name }}</strong>
-                    <span class="text-muted" style="font-size:0.85em;opacity:0.7">{{ c.email }}</span>
-                    <span class="text-muted">{{ c.commits }}</span>
-                  </span>
-                </div>
-              </div>
-
-              <!-- Top 5 Improvements -->
-              <div *ngIf="reportData.top5Improvements?.length" class="insights-improvements">
-                <h3 class="insights-improvements-title">
-                  <i class="bi bi-arrow-up-circle"></i> Top Improvements
-                </h3>
-                <div *ngFor="let imp of reportData.top5Improvements; let i = index" class="insights-improvement-item">
-                  <span class="insights-improvement-num">{{ i + 1 }}</span>
-                  <div class="insights-improvement-body">
-                    <div class="insights-improvement-title">{{ imp.title }}</div>
-                    <div *ngIf="imp.description" class="insights-improvement-desc">{{ imp.description }}</div>
-                  </div>
-                  <span class="badge insights-impact-badge"
-                        [ngClass]="imp.impact === 'high' || imp.impact === 'critical' ? 'badge-danger' : imp.impact === 'medium' ? 'badge-warning' : 'badge-info'"
-                        style="font-size:0.6875rem;text-transform:capitalize">{{ imp.impact }}</span>
-                </div>
-              </div>
-            </div><!-- end *ngIf="reportData" -->
-            </div><!-- end insights-section report-summary -->
-
-            <!-- Each Insight Layer Section -->
-            <div *ngFor="let layer of insightLayers; let idx = index"
-                 class="insights-section insights-layer-section"
-                 [id]="'layer-' + layer.subtype">
-
-              <!-- Section Heading -->
-              <div class="insights-layer-heading">
-                <div class="insights-layer-heading-left">
-                  <span class="insights-layer-num">{{ idx + 1 }}</span>
-                  <h2 class="insights-layer-title">{{ getInsightLabel(layer.subtype) }}</h2>
-                </div>
-                <div class="insights-layer-stars" *ngIf="getLayerRating(layer.subtype) as rating">
-                  {{ getStarRating(rating) }}
-                </div>
-              </div>
-
-              <!-- Ratings Badges -->
-              <div *ngIf="getLayerReport(layer.subtype) as lr" class="insights-layer-badges">
-                <span class="badge insights-badge-maturity"
-                      [ngClass]="lr.maturityRating >= 4 ? 'badge-success' : lr.maturityRating >= 3 ? 'badge-warning' : 'badge-danger'">
-                  <i class="bi bi-bar-chart-fill"></i> Maturity {{ lr.maturityRating }}/5
-                  <span class="report-info-icon report-info-inline report-info-below" data-tooltip="1=Initial, 2=Developing, 3=Defined, 4=Managed, 5=Optimized"><i class="bi bi-info-circle"></i></span>
-                </span>
-                <span class="badge insights-badge-quality"
-                      [ngClass]="lr.qualityRating >= 4 ? 'badge-success' : lr.qualityRating >= 3 ? 'badge-warning' : 'badge-danger'">
-                  <i class="bi bi-star-fill"></i> Quality {{ lr.qualityRating }}/5
-                  <span class="report-info-icon report-info-inline report-info-below" data-tooltip="1=Poor, 2=Fair, 3=Good, 4=Very Good, 5=Excellent"><i class="bi bi-info-circle"></i></span>
-                </span>
-                <span class="badge insights-badge-risk"
-                      [ngClass]="lr.riskRating <= 2 ? 'badge-success' : lr.riskRating <= 3 ? 'badge-warning' : 'badge-danger'">
-                  <i class="bi bi-shield-fill"></i> Risk {{ lr.riskRating }}/5
-                  <span class="report-info-icon report-info-inline report-info-below" data-tooltip="1=Low, 2=Minor, 3=Moderate, 4=Significant, 5=Critical"><i class="bi bi-info-circle"></i></span>
-                </span>
-              </div>
-
-              <!-- Strengths / Weaknesses / Recommendations -->
-              <div *ngIf="getLayerReport(layer.subtype) as lr" class="insights-layer-meta">
-                <div class="insights-meta-block">
-                  <div class="insights-meta-title insights-meta-strengths"><i class="bi bi-check-circle-fill"></i> Strengths</div>
-                  <ul *ngIf="lr.strengths?.length" class="insights-meta-list">
-                    <li *ngFor="let s of lr.strengths" class="insights-strength-item">{{ s }}</li>
-                  </ul>
-                  <div *ngIf="!lr.strengths?.length" class="text-muted" style="font-size:var(--font-xs);padding:0.25rem 0">Generate report to see ratings</div>
-                </div>
-                <div class="insights-meta-block">
-                  <div class="insights-meta-title insights-meta-weaknesses"><i class="bi bi-exclamation-triangle-fill"></i> Weaknesses</div>
-                  <ul *ngIf="lr.weaknesses?.length" class="insights-meta-list">
-                    <li *ngFor="let w of lr.weaknesses" class="insights-weakness-item">{{ w }}</li>
-                  </ul>
-                  <div *ngIf="!lr.weaknesses?.length" class="text-muted" style="font-size:var(--font-xs);padding:0.25rem 0">Generate report to see ratings</div>
-                </div>
-                <div class="insights-meta-block">
-                  <div class="insights-meta-title insights-meta-recommendations"><i class="bi bi-arrow-right-circle-fill"></i> Recommendations</div>
-                  <ul *ngIf="lr.recommendations?.length" class="insights-meta-list">
-                    <li *ngFor="let r of lr.recommendations" class="insights-recommendation-item">{{ r }}</li>
-                  </ul>
-                  <div *ngIf="!lr.recommendations?.length" class="text-muted" style="font-size:var(--font-xs);padding:0.25rem 0">Generate report to see recommendations</div>
-                </div>
-              </div>
-
-              <!-- Rendered Markdown Content -->
-              <div class="insights-layer-content" [innerHTML]="renderInsightHtml(layer)"></div>
-            </div>
-
-            <!-- Methodology -->
-            <div class="insights-section report-methodology-section" id="insights-methodology" style="margin-top:2rem">
-              <h2 class="report-section-title">
-                <i class="bi bi-info-circle"></i> Methodology
-              </h2>
-              <div class="report-methodology-toggle" (click)="showInsightsMethodology = !showInsightsMethodology">
-                <i class="bi" [ngClass]="showInsightsMethodology ? 'bi-chevron-up' : 'bi-chevron-down'"></i>
-                {{ showInsightsMethodology ? 'Hide methodology details' : 'Show methodology details' }}
-              </div>
-              <div class="report-methodology-content" [class.report-methodology-expanded]="showInsightsMethodology">
-                <div class="report-methodology-grid">
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Health Score</div>
-                    <div class="report-methodology-def">Weighted average: Maturity (40%) + Quality (40%) + (5 - Risk)/5 (20%). Scale 0-100.</div>
-                  </div>
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Commits/Month</div>
-                    <div class="report-methodology-def">Total commits divided by the repository's active period in months.</div>
-                  </div>
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Active Contributors</div>
-                    <div class="report-methodology-def">Unique committer emails across all indexed commits.</div>
-                  </div>
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Trend</div>
-                    <div class="report-methodology-def">Compares commit rate in the second half of the repo's history vs the first half. Increasing if >20% higher, decreasing if >20% lower.</div>
-                  </div>
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Maturity Rating</div>
-                    <div class="report-methodology-def">1=Initial, 2=Developing, 3=Defined, 4=Managed, 5=Optimized.</div>
-                  </div>
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Quality Rating</div>
-                    <div class="report-methodology-def">1=Poor, 2=Fair, 3=Good, 4=Very Good, 5=Excellent.</div>
-                  </div>
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Risk Rating</div>
-                    <div class="report-methodology-def">1=Low, 2=Minor, 3=Moderate, 4=Significant, 5=Critical.</div>
-                  </div>
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Impact / Effort</div>
-                    <div class="report-methodology-def">Impact: expected improvement. Effort: implementation cost. Both rated high/medium/low.</div>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-          </div><!-- End Content Area -->
-        </div><!-- End Document Wrapper -->
-
-      </div><!-- End Insights Tab -->
-
-      <!-- Report Tab -->
-      <div *ngIf="activeTab === 'Report'" class="report-tab">
-        <!-- Toolbar -->
-        <div class="report-toolbar">
-          <div class="report-toolbar-left">
-            <i class="bi bi-file-earmark-bar-graph" style="font-size:1.125rem;color:var(--primary)"></i>
-            <span style="font-weight:600;font-size:var(--font-sm)">Repository Report</span>
-          </div>
-          <div class="report-toolbar-right">
-            <button class="btn btn-primary btn-sm" (click)="generateReport()" [disabled]="generatingReport || !insightLayers.length">
-              <i class="bi bi-file-earmark-bar-graph"></i> {{ generatingReport ? 'Generating...' : (reportData ? 'Regenerate Report' : 'Generate Report') }}
-            </button>
-            <button *ngIf="reportData" (click)="exportHtml()" class="btn btn-secondary btn-sm">
-              <i class="bi bi-download"></i> Export HTML
-            </button>
-            <button *ngIf="reportData" (click)="exportPdf()" class="btn btn-secondary btn-sm">
-              <i class="bi bi-file-earmark-pdf"></i> Save as PDF
-            </button>
-            <span *ngIf="!insightLayers.length" class="text-muted" style="font-size:var(--font-xs);align-self:center">Generate insights first.</span>
-          </div>
-        </div>
-
-        <!-- Empty state -->
-        <div *ngIf="!reportData && !generatingReport" class="report-empty card">
-          <i class="bi bi-file-earmark-bar-graph" style="font-size:2.5rem;color:var(--text-light);margin-bottom:1rem;display:block"></i>
-          <h3 style="font-size:var(--font-lg);margin-bottom:0.5rem">No report yet</h3>
-          <p class="text-muted" style="font-size:var(--font-xs);margin-bottom:1.25rem">Generate insights first, then click "Generate Report" to produce a comprehensive analysis.</p>
-          <div *ngIf="reportError" style="margin-bottom:1rem;padding:0.75rem 1rem;background:rgba(220,53,69,0.08);border:1px solid rgba(220,53,69,0.2);border-radius:var(--radius);color:var(--danger);font-size:var(--font-xs)">
-            <i class="bi bi-exclamation-triangle"></i> {{ reportError }}
-          </div>
-          <button class="btn btn-primary" (click)="generateReport()" [disabled]="generatingReport || !insightLayers.length">
-            <i class="bi bi-file-earmark-bar-graph"></i> Generate Report
-          </button>
-        </div>
-
-        <!-- Report document with TOC sidebar -->
-        <div *ngIf="reportData" class="report-document-wrapper" id="reportDocumentWrapper">
-
-          <!-- TOC Sidebar -->
-          <nav class="report-toc" id="reportToc">
-            <div class="report-toc-title">Contents</div>
-            <a class="report-toc-item"
-               [class.active]="activeReportSection === 'rpt-health'"
-               (click)="scrollToReportSection('rpt-health', $event)">
-              <span class="report-toc-score"
-                    [style.background]="reportData.overallHealthScore >= 70 ? 'var(--success)' : reportData.overallHealthScore >= 40 ? '#e6a700' : 'var(--danger)'">
-                {{ reportData.overallHealthScore }}
-              </span>
-              Health Score
-            </a>
-            <a class="report-toc-item"
-               [class.active]="activeReportSection === 'rpt-velocity'"
-               (click)="scrollToReportSection('rpt-velocity', $event)">
-              <i class="bi bi-speedometer2"></i> Velocity
-            </a>
-            <a class="report-toc-item"
-               [class.active]="activeReportSection === 'rpt-layers-overview'"
-               (click)="scrollToReportSection('rpt-layers-overview', $event)">
-              <i class="bi bi-grid"></i> Layer Overview
-            </a>
-            <a *ngIf="reportData.top5Improvements?.length" class="report-toc-item"
-               [class.active]="activeReportSection === 'rpt-improvements'"
-               (click)="scrollToReportSection('rpt-improvements', $event)">
-              <i class="bi bi-arrow-up-circle"></i> Top Improvements
-            </a>
-            <div class="report-toc-divider"></div>
-            <a *ngFor="let layer of reportData.layers; let i = index" class="report-toc-item"
-               [class.active]="activeReportSection === 'rpt-layer-' + layer.subtype"
-               (click)="scrollToReportSection('rpt-layer-' + layer.subtype, $event)">
-              <span class="report-toc-num">{{ i + 1 }}</span>
-              {{ getInsightLabel(layer.subtype) || layer.name }}
-              <span class="report-toc-rating">{{ getStarRating(layer.qualityRating) }}</span>
-            </a>
-            <div class="report-toc-divider"></div>
-            <a class="report-toc-item"
-               [class.active]="activeReportSection === 'rpt-methodology'"
-               (click)="scrollToReportSection('rpt-methodology', $event)">
-              <i class="bi bi-info-circle"></i> Methodology
-            </a>
-          </nav>
-
-          <!-- Content Area (single scrollable document) -->
-          <div class="report-content-area" id="reportContentArea" (scroll)="onReportScroll($event)">
-
-            <!-- Tech Stack Summary Bar -->
-            <div *ngIf="techStackSummary?.length" style="display:flex;flex-wrap:wrap;gap:0.5rem;margin-bottom:1.5rem">
-              <span *ngFor="let tech of techStackSummary" class="badge badge-primary" style="font-size:var(--font-xs)">{{ tech }}</span>
-            </div>
-
-            <!-- Section 1: Health Score -->
-            <section class="report-section" id="rpt-health">
-              <div class="report-health-header">
-                <div class="report-health-score-ring"
-                     [style.borderColor]="reportData.overallHealthScore >= 70 ? 'var(--success)' : reportData.overallHealthScore >= 40 ? '#e6a700' : 'var(--danger)'">
-                  <div class="report-health-number"
-                       [style.color]="reportData.overallHealthScore >= 70 ? 'var(--success)' : reportData.overallHealthScore >= 40 ? '#e6a700' : 'var(--danger)'">
-                    {{ reportData.overallHealthScore }}
-                  </div>
-                  <div class="report-health-of">/100</div>
-                  <div class="report-health-label">Health Score</div>
-                  <span class="report-info-icon" data-tooltip="Weighted average: Maturity (40%) + Quality (40%) + (5 - Risk)/5 (20%). Scale 0-100.">
-                    <i class="bi bi-info-circle"></i>
-                  </span>
-                </div>
-                <div class="report-health-stars" *ngIf="reportData.overallHealthScore != null">
-                  {{ getStarRating(Math.round(reportData.overallHealthScore / 20)) }}
-                </div>
-              </div>
-
-              <!-- Ratings summary grid -->
-              <div class="report-ratings-grid" *ngIf="reportData.layers?.length">
-                <div *ngFor="let lr of reportData.layers" class="report-rating-row">
-                  <span class="report-rating-label">{{ getInsightLabel(lr.subtype) }}</span>
-                  <span class="report-rating-stars">{{ getStarRating(lr.qualityRating) }}</span>
-                  <span class="report-rating-value">{{ lr.qualityRating }}/5</span>
-                </div>
-              </div>
-            </section>
-
-            <!-- Section 2: Velocity Metrics -->
-            <section class="report-section" id="rpt-velocity" *ngIf="reportData.velocity">
-              <h2 class="report-section-title">
-                <i class="bi bi-speedometer2"></i> Velocity Metrics
-              </h2>
-              <div class="report-velocity-grid">
-                <div class="report-velocity-card">
-                  <div class="report-velocity-value">{{ reportData.velocity.commitsPerMonth }}</div>
-                  <div class="report-velocity-label">
-                    Commits/Month
-                    <span class="report-info-icon" data-tooltip="Total commits divided by the repository's active period in months.">
-                      <i class="bi bi-info-circle"></i>
-                    </span>
-                  </div>
-                </div>
-                <div class="report-velocity-card">
-                  <div class="report-velocity-value">{{ reportData.velocity.activeContributors }}</div>
-                  <div class="report-velocity-label">
-                    Active Contributors
-                    <span class="report-info-icon" data-tooltip="Unique committer emails across all indexed commits.">
-                      <i class="bi bi-info-circle"></i>
-                    </span>
-                  </div>
-                </div>
-                <div class="report-velocity-card">
-                  <div class="report-velocity-value report-velocity-trend" style="text-transform:capitalize">{{ reportData.velocity.trend }}</div>
-                  <div class="report-velocity-label">
-                    Trend
-                    <span class="report-info-icon" data-tooltip="Compares commit rate in the second half of the repo's history vs the first half. Increasing if >20% higher, decreasing if >20% lower.">
-                      <i class="bi bi-info-circle"></i>
-                    </span>
-                  </div>
-                </div>
-                <div class="report-velocity-card" *ngIf="reportData.velocity.averageCommitsPerDay != null">
-                  <div class="report-velocity-value">{{ reportData.velocity.averageCommitsPerDay | number:'1.1-1' }}</div>
-                  <div class="report-velocity-label">Commits/Day</div>
-                </div>
-                <div class="report-velocity-card" *ngIf="reportData.velocity.deployFrequency">
-                  <div class="report-velocity-value">{{ reportData.velocity.deployFrequency }}</div>
-                  <div class="report-velocity-label">Deploy Frequency</div>
-                </div>
-              </div>
-
-              <!-- Top Contributors -->
-              <div *ngIf="reportData.velocity?.topContributors?.length" style="margin-top:1.25rem">
-                <div style="font-weight:600;font-size:var(--font-xs);margin-bottom:0.5rem;color:var(--text-muted)">Top Contributors</div>
-                <div style="display:flex;flex-wrap:wrap;gap:0.5rem">
-                  <span *ngFor="let c of reportData.velocity.topContributors" style="display:inline-flex;align-items:center;gap:0.375rem;padding:0.25rem 0.625rem;background:var(--background-alt);border-radius:100px;font-size:var(--font-xs)">
-                    <strong>{{ c.name }}</strong>
-                    <span class="text-muted" style="font-size:0.85em;opacity:0.7">{{ c.email }}</span>
-                    <span class="text-muted">{{ c.commits }}</span>
-                  </span>
-                </div>
-              </div>
-            </section>
-
-            <!-- Section 3: Layer Overview Grid -->
-            <section class="report-section" id="rpt-layers-overview">
-              <h2 class="report-section-title">
-                <i class="bi bi-grid"></i> Layer Overview
-              </h2>
-              <div class="report-layer-overview-grid">
-                <div *ngFor="let layer of reportData.layers" class="report-layer-card"
-                     (click)="scrollToReportSection('rpt-layer-' + layer.subtype, $event)">
-                  <div class="report-layer-card-header">
-                    <span class="report-layer-card-name">{{ getInsightLabel(layer.subtype) || layer.name }}</span>
-                    <span class="report-layer-card-stars">{{ getStarRating(layer.qualityRating) }}</span>
-                  </div>
-                  <div class="report-layer-card-badges">
-                    <span class="report-mini-badge"
-                          [ngClass]="layer.maturityRating >= 4 ? 'mini-success' : layer.maturityRating >= 3 ? 'mini-warning' : 'mini-danger'">
-                      M:{{ layer.maturityRating }}
-                    </span>
-                    <span class="report-mini-badge"
-                          [ngClass]="layer.qualityRating >= 4 ? 'mini-success' : layer.qualityRating >= 3 ? 'mini-warning' : 'mini-danger'">
-                      Q:{{ layer.qualityRating }}
-                    </span>
-                    <span class="report-mini-badge"
-                          [ngClass]="layer.riskRating <= 2 ? 'mini-success' : layer.riskRating <= 3 ? 'mini-warning' : 'mini-danger'">
-                      R:{{ layer.riskRating }}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            <!-- Section 4: Top Improvements -->
-            <section class="report-section" id="rpt-improvements" *ngIf="reportData.top5Improvements?.length">
-              <h2 class="report-section-title">
-                <i class="bi bi-arrow-up-circle"></i> Top Improvements
-              </h2>
-              <div class="report-improvements-list">
-                <div *ngFor="let imp of reportData.top5Improvements; let i = index" class="report-improvement-item">
-                  <span class="report-improvement-num">{{ i + 1 }}</span>
-                  <div class="report-improvement-body">
-                    <div class="report-improvement-title">{{ imp.title }}</div>
-                    <div *ngIf="imp.description" class="report-improvement-desc">{{ imp.description }}</div>
-                    <div class="report-improvement-badges">
-                      <span class="badge"
-                            [ngClass]="imp.impact === 'high' || imp.impact === 'critical' ? 'badge-danger' : imp.impact === 'medium' ? 'badge-warning' : 'badge-muted'"
-                            style="font-size:0.6875rem;text-transform:capitalize">
-                        {{ imp.impact }} impact
-                        <span class="report-info-icon" data-tooltip="Impact: expected improvement. Effort: implementation cost. Both rated high/medium/low.">
-                          <i class="bi bi-info-circle"></i>
-                        </span>
-                      </span>
-                      <span class="badge badge-muted" style="font-size:0.6875rem;text-transform:capitalize">{{ imp.effort }} effort</span>
-                      <span *ngIf="imp.layer" class="badge badge-muted" style="font-size:0.6875rem">{{ getInsightLabel(imp.layer) || imp.layer }}</span>
+                    <div class="stat">
+                      <div class="stat-value" [style.color]="repo.stats.hasEmbeddings ? 'var(--primary)' : 'var(--text-muted)'">
+                        {{ repo.stats.embeddingCount }}
+                      </div>
+                      <div class="stat-label">Embeddings</div>
                     </div>
+                    <div class="stat"><div class="stat-value">{{ repo.stats.pendingTaskCount }}</div><div class="stat-label">Pending Tasks</div></div>
                   </div>
+                  @if (!repo.stats.hasEmbeddings && repo.status === 'indexed') {
+                    <div
+                      style="margin-top:0.75rem;padding:0.5rem 0.75rem;background:rgba(255,193,7,0.08);border-radius:var(--radius);font-size:0.8125rem;color:#856404">
+                      <i class="bi bi-info-circle"></i> No embeddings -- semantic search unavailable. Configure an embedding API key in Settings.
+                    </div>
+                  }
+                </div>
+              }
+            </div>
+            <!-- Summary stats from analytics endpoint -->
+            @if (summary) {
+              <div style="display:grid;grid-template-columns:1fr 1fr;gap:1.5rem;margin-bottom:1.5rem">
+                <div class="card">
+                  <h3 style="margin-bottom:1rem;font-size:1rem">Last Commit</h3>
+                  @if (summary.lastCommit) {
+                    <div>
+                      <div style="font-weight:500;margin-bottom:0.25rem">{{ summary.lastCommit.authorName }}</div>
+                      <div class="text-muted" style="font-size:0.8125rem;margin-bottom:0.5rem">{{ summary.lastCommit.authorEmail }}</div>
+                      <div style="font-size:0.875rem;margin-bottom:0.5rem">{{ summary.lastCommit.message }}</div>
+                      <div class="text-muted" style="font-size:0.8125rem">
+                        <code>{{ summary.lastCommit.sha?.substring(0, 8) }}</code>
+                        <span style="margin-left:0.5rem">{{ getRelativeTime(summary.lastCommit.committedAt) }}</span>
+                      </div>
+                    </div>
+                  }
+                  @if (!summary.lastCommit) {
+                    <div class="text-muted">No commits found</div>
+                  }
+                </div>
+                <div class="card">
+                  <h3 style="margin-bottom:1rem;font-size:1rem">File Breakdown</h3>
+                  <div class="stat-grid" style="grid-template-columns:repeat(3, 1fr)">
+                    <div class="stat"><div class="stat-value">{{ summary.stats.totalFiles }}</div><div class="stat-label">Total Files</div></div>
+                    <div class="stat"><div class="stat-value">{{ summary.stats.testFiles }}</div><div class="stat-label">Test Files</div></div>
+                    <div class="stat"><div class="stat-value">{{ summary.stats.apiDocs }}</div><div class="stat-label">API Docs</div></div>
+                  </div>
+                  @if (summary.enrichmentsByType && summary.enrichmentsByType.length > 0) {
+                    <div style="margin-top:1rem">
+                      <div class="text-muted" style="font-size:0.75rem;margin-bottom:0.5rem;font-weight:500;text-transform:uppercase;letter-spacing:0.05em">Enrichments by type</div>
+                      <div style="display:flex;flex-wrap:wrap;gap:0.375rem">
+                        @for (et of summary.enrichmentsByType; track et) {
+                          <span class="badge badge-muted">{{ et.subtype }} ({{ et.count }})</span>
+                        }
+                      </div>
+                    </div>
+                  }
                 </div>
               </div>
-            </section>
-
-            <!-- Section 5+: Each Layer Section (all rendered, not toggled) -->
-            <section *ngFor="let layer of reportData.layers; let idx = index"
-                     class="report-section report-layer-section"
-                     [id]="'rpt-layer-' + layer.subtype">
-
-              <!-- Section Heading -->
-              <div class="report-layer-heading">
-                <div class="report-layer-heading-left">
-                  <span class="report-layer-num">{{ idx + 1 }}</span>
-                  <h2 class="report-layer-title">{{ getInsightLabel(layer.subtype) || layer.name }}</h2>
-                </div>
-                <div class="report-layer-heading-stars">
-                  {{ getStarRating(layer.qualityRating) }}
+            }
+            @if (repo.branches && repo.branches.length > 0) {
+              <div class="card">
+                <h3 style="margin-bottom:1rem;font-size:1rem">Branches</h3>
+                <div class="tag-list">
+                  @for (branch of repo.branches; track branch) {
+                    <span class="badge" [ngClass]="branch.isDefault ? 'badge-primary' : 'badge-muted'">
+                      {{ branch.name }}
+                    </span>
+                  }
                 </div>
               </div>
-
-              <!-- Rating Badges -->
-              <div class="report-layer-badges">
-                <span class="badge report-badge-maturity"
-                      [ngClass]="layer.maturityRating >= 4 ? 'badge-success' : layer.maturityRating >= 3 ? 'badge-warning' : 'badge-danger'">
-                  <i class="bi bi-bar-chart-fill"></i> Maturity {{ layer.maturityRating }}/5
-                  <span class="report-info-icon report-info-inline" data-tooltip="1=Initial, 2=Developing, 3=Defined, 4=Managed, 5=Optimized.">
-                    <i class="bi bi-info-circle"></i>
-                  </span>
-                </span>
-                <span class="badge report-badge-quality"
-                      [ngClass]="layer.qualityRating >= 4 ? 'badge-success' : layer.qualityRating >= 3 ? 'badge-warning' : 'badge-danger'">
-                  <i class="bi bi-star-fill"></i> Quality {{ layer.qualityRating }}/5
-                  <span class="report-info-icon report-info-inline" data-tooltip="1=Poor, 2=Fair, 3=Good, 4=Very Good, 5=Excellent.">
-                    <i class="bi bi-info-circle"></i>
-                  </span>
-                </span>
-                <span class="badge report-badge-risk"
-                      [ngClass]="layer.riskRating <= 2 ? 'badge-success' : layer.riskRating <= 3 ? 'badge-warning' : 'badge-danger'">
-                  <i class="bi bi-shield-fill"></i> Risk {{ layer.riskRating }}/5
-                  <span class="report-info-icon report-info-inline" data-tooltip="1=Low, 2=Minor, 3=Moderate, 4=Significant, 5=Critical.">
-                    <i class="bi bi-info-circle"></i>
-                  </span>
-                </span>
-              </div>
-
-              <!-- Strengths / Weaknesses / Recommendations -->
-              <div class="report-layer-meta">
-                <div *ngIf="layer.strengths?.length" class="report-meta-block">
-                  <div class="report-meta-title report-meta-strengths"><i class="bi bi-check-circle-fill"></i> Strengths</div>
-                  <ul class="report-meta-list">
-                    <li *ngFor="let s of layer.strengths" class="report-strength-item">{{ s }}</li>
-                  </ul>
+            }
+            <!-- Commit Comparison -->
+            @if (commits.length >= 2) {
+              <div class="card" style="margin-top:1.5rem">
+                <h3 style="margin-bottom:1rem;font-size:1rem">Compare Commits</h3>
+                <div style="display:flex;gap:0.75rem;align-items:flex-end;flex-wrap:wrap">
+                  <div>
+                    <label style="font-size:0.75rem;color:var(--text-muted);display:block;margin-bottom:0.25rem">From</label>
+                    <select [(ngModel)]="compareFrom" style="padding:0.375rem 0.5rem;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);color:var(--text);font-size:0.8125rem;min-width:200px">
+                      <option value="">Select commit...</option>
+                      @for (c of commits; track c) {
+                        <option [value]="c.sha">{{ c.sha.substring(0, 7) }} - {{ c.message | slice:0:40 }}</option>
+                      }
+                    </select>
+                  </div>
+                  <div>
+                    <label style="font-size:0.75rem;color:var(--text-muted);display:block;margin-bottom:0.25rem">To</label>
+                    <select [(ngModel)]="compareTo" style="padding:0.375rem 0.5rem;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);color:var(--text);font-size:0.8125rem;min-width:200px">
+                      <option value="">Select commit...</option>
+                      @for (c of commits; track c) {
+                        <option [value]="c.sha">{{ c.sha.substring(0, 7) }} - {{ c.message | slice:0:40 }}</option>
+                      }
+                    </select>
+                  </div>
+                  <button class="btn btn-primary" (click)="compareCommits()" [disabled]="!compareFrom || !compareTo || comparing" style="font-size:0.8125rem">
+                    <i class="bi bi-arrow-left-right"></i> Compare
+                  </button>
                 </div>
-                <div *ngIf="layer.weaknesses?.length" class="report-meta-block">
-                  <div class="report-meta-title report-meta-weaknesses"><i class="bi bi-exclamation-triangle-fill"></i> Weaknesses</div>
-                  <ul class="report-meta-list">
-                    <li *ngFor="let w of layer.weaknesses" class="report-weakness-item">{{ w }}</li>
-                  </ul>
+                @if (compareError) {
+                  <div style="margin-top:0.75rem;color:var(--danger);font-size:0.8125rem">{{ compareError }}</div>
+                }
+                <!-- Comparison Results -->
+                @if (comparison) {
+                  <div style="margin-top:1rem">
+                    <div style="display:flex;gap:1rem;margin-bottom:1rem">
+                      <span class="stat-badge added" style="cursor:pointer" (click)="toggleSection('added')">+ {{ comparison.added.length }} added</span>
+                      <span class="stat-badge deleted" style="cursor:pointer" (click)="toggleSection('removed')">- {{ comparison.removed.length }} removed</span>
+                      <span class="stat-badge updated" style="cursor:pointer" (click)="toggleSection('changed')">~ {{ comparison.changed.length }} changed</span>
+                    </div>
+                    @if (expandedSection === 'added' && comparison.added.length > 0) {
+                      <div style="margin-top:0.75rem">
+                        <h4 style="font-size:0.875rem;margin-bottom:0.5rem;color:var(--success)">Added Enrichments</h4>
+                        @for (e of comparison.added; track e) {
+                          <div class="compare-item">
+                            <div style="font-weight:500;font-size:0.8125rem">{{ e.filePath || '(no file)' }}</div>
+                            <span class="badge badge-muted" style="font-size:0.6875rem">{{ e.subtype }}</span>
+                            <div class="text-muted" style="font-size:0.75rem;margin-top:0.25rem;white-space:pre-wrap;max-height:4rem;overflow:hidden">{{ e.content | slice:0:200 }}</div>
+                          </div>
+                        }
+                      </div>
+                    }
+                    @if (expandedSection === 'removed' && comparison.removed.length > 0) {
+                      <div style="margin-top:0.75rem">
+                        <h4 style="font-size:0.875rem;margin-bottom:0.5rem;color:var(--danger)">Removed Enrichments</h4>
+                        @for (e of comparison.removed; track e) {
+                          <div class="compare-item">
+                            <div style="font-weight:500;font-size:0.8125rem">{{ e.filePath || '(no file)' }}</div>
+                            <span class="badge badge-muted" style="font-size:0.6875rem">{{ e.subtype }}</span>
+                            <div class="text-muted" style="font-size:0.75rem;margin-top:0.25rem;white-space:pre-wrap;max-height:4rem;overflow:hidden">{{ e.content | slice:0:200 }}</div>
+                          </div>
+                        }
+                      </div>
+                    }
+                    @if (expandedSection === 'changed' && comparison.changed.length > 0) {
+                      <div style="margin-top:0.75rem">
+                        <h4 style="font-size:0.875rem;margin-bottom:0.5rem;color:var(--accent)">Changed Enrichments</h4>
+                        @for (c of comparison.changed; track c) {
+                          <div class="compare-item">
+                            <div style="font-weight:500;font-size:0.8125rem">{{ c.to.filePath || '(no file)' }}</div>
+                            <span class="badge badge-muted" style="font-size:0.6875rem">{{ c.to.subtype }}</span>
+                          </div>
+                        }
+                      </div>
+                    }
+                  </div>
+                }
+              </div>
+            }
+          </div>
+          }<!-- End Overview Tab -->
+          <!-- Insights Tab -->
+          @if (activeTab === 'Insights') {
+            <div class="insights-tab">
+              <!-- Toolbar -->
+              <div class="insights-toolbar">
+                <div class="insights-toolbar-left">
+                  <i class="bi bi-journal-richtext" style="font-size:1.125rem;color:var(--primary)"></i>
+                  <span style="font-weight:600;font-size:var(--font-sm)">Repository Insights Report</span>
+                  @if (insightLayers.length > 0 && insightLayers[0].createdAt) {
+                    <span class="text-muted" style="font-size:var(--font-xs);margin-left:0.75rem">
+                      Generated {{ getRelativeTime(insightLayers[0].createdAt || insightLayers[0].CreatedAt) }}
+                    </span>
+                  }
                 </div>
-                <div *ngIf="layer.recommendations?.length" class="report-meta-block report-meta-block-full">
-                  <div class="report-meta-title report-meta-recommendations"><i class="bi bi-arrow-right-circle-fill"></i> Recommendations</div>
-                  <ul class="report-meta-list">
-                    <li *ngFor="let r of layer.recommendations" class="report-recommendation-item">{{ r }}</li>
-                  </ul>
+                <div class="insights-toolbar-right">
+                  <button class="btn btn-secondary btn-sm" (click)="generateInsights()" [disabled]="generatingInsights">
+                    <i class="bi bi-lightbulb"></i> {{ generatingInsights ? 'Generating (' + insightLayers.length + '/11)...' : (insightLayers.length > 0 ? 'Regenerate' : 'Generate Insights') }}
+                  </button>
+                  @if (generatingInsights && insightsProgressMessage) {
+                    <span class="insights-progress-label" style="font-size:var(--font-xs);color:var(--text-light);margin-left:0.5rem;white-space:nowrap">
+                      {{ insightsProgressMessage }}
+                    </span>
+                  }
+                  <button class="btn btn-secondary btn-sm" (click)="generateReport()" [disabled]="generatingReport || !insightLayers.length">
+                    <i class="bi bi-file-earmark-bar-graph"></i> {{ generatingReport ? 'Generating...' : 'Generate Report' }}
+                  </button>
+                  @if (insightLayers.length > 0) {
+                    <button (click)="exportHtml()" class="btn btn-secondary btn-sm">
+                      <i class="bi bi-download"></i> Export HTML
+                    </button>
+                  }
+                  @if (insightLayers.length > 0) {
+                    <button class="btn btn-secondary btn-sm" (click)="printReport()">
+                      <i class="bi bi-printer"></i> Print
+                    </button>
+                  }
                 </div>
               </div>
-            </section>
-
-            <!-- Methodology Section -->
-            <section class="report-section report-methodology-section" id="rpt-methodology">
-              <h2 class="report-section-title">
-                <i class="bi bi-info-circle"></i> Methodology
-              </h2>
-              <div class="report-methodology-toggle" (click)="showMethodology = !showMethodology">
-                <i class="bi" [ngClass]="showMethodology ? 'bi-chevron-up' : 'bi-chevron-down'"></i>
-                {{ showMethodology ? 'Hide methodology details' : 'Show methodology details' }}
-              </div>
-              <div class="report-methodology-content" [class.report-methodology-expanded]="showMethodology">
-                <div class="report-methodology-grid">
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Health Score</div>
-                    <div class="report-methodology-def">Weighted average: Maturity (40%) + Quality (40%) + (5 - Risk)/5 (20%). Scale 0-100.</div>
-                  </div>
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Commits/Month</div>
-                    <div class="report-methodology-def">Total commits divided by the repository's active period in months.</div>
-                  </div>
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Active Contributors</div>
-                    <div class="report-methodology-def">Unique committer emails across all indexed commits.</div>
-                  </div>
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Trend</div>
-                    <div class="report-methodology-def">Compares commit rate in the second half of the repo's history vs the first half. Increasing if >20% higher, decreasing if >20% lower.</div>
-                  </div>
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Maturity Rating</div>
-                    <div class="report-methodology-def">1=Initial, 2=Developing, 3=Defined, 4=Managed, 5=Optimized.</div>
-                  </div>
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Quality Rating</div>
-                    <div class="report-methodology-def">1=Poor, 2=Fair, 3=Good, 4=Very Good, 5=Excellent.</div>
-                  </div>
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Risk Rating</div>
-                    <div class="report-methodology-def">1=Low, 2=Minor, 3=Moderate, 4=Significant, 5=Critical.</div>
-                  </div>
-                  <div class="report-methodology-item">
-                    <div class="report-methodology-term">Impact / Effort</div>
-                    <div class="report-methodology-def">Impact: expected improvement. Effort: implementation cost. Both rated high/medium/low.</div>
+              <!-- Progress Bar -->
+              @if (generatingInsights) {
+                <div class="insights-progress-bar-container" style="padding:0 1rem 0.5rem 1rem">
+                  <div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.25rem">
+                    <div style="flex:1;height:6px;background:var(--border);border-radius:3px;overflow:hidden">
+                      <div [style.width.%]="insightsProgress" style="height:100%;background:var(--primary);border-radius:3px;transition:width 0.5s ease"></div>
+                    </div>
+                    <span style="font-size:var(--font-xs);color:var(--text-light);min-width:2.5rem;text-align:right">{{ insightsProgress }}%</span>
                   </div>
                 </div>
-              </div>
-            </section>
-
-          </div><!-- End Content Area -->
-        </div><!-- End Document Wrapper -->
-      </div><!-- End Report Tab -->
-
-      <!-- History Tab -->
-      <div *ngIf="activeTab === 'History'">
-        <app-repository-history [repositoryId]="repo.id" [ref]="selectedRef" style="display:block" />
-      </div>
-
-      <!-- Analytics Tab -->
-      <div *ngIf="activeTab === 'Analytics'">
-        <app-repository-analytics [repositoryId]="repo.id" />
-      </div>
-    </div>
-
-    <div *ngIf="!loading && !repo" class="empty-state card">
-      <i class="bi bi-exclamation-circle"></i>
-      <h3>Repository not found</h3>
-      <a routerLink="/repositories" class="btn btn-primary mt-2">Back to Repositories</a>
-    </div>
-  `,
+              }
+              <!-- Empty State -->
+              @if (insightLayers.length === 0 && !generatingInsights) {
+                <div class="insights-empty card">
+                  <i class="bi bi-lightbulb" style="font-size:2.5rem;color:var(--text-light);margin-bottom:1rem;display:block"></i>
+                  <h3 style="font-size:var(--font-lg);margin-bottom:0.5rem">No insights yet</h3>
+                  <p class="text-muted" style="font-size:var(--font-xs);margin-bottom:1.25rem">Click "Generate Insights" to analyze this repository and produce a comprehensive report.</p>
+                  <button class="btn btn-primary" (click)="generateInsights()" [disabled]="generatingInsights">
+                    <i class="bi bi-lightbulb"></i> Generate Insights
+                  </button>
+                </div>
+              }
+              <!-- Report Document -->
+              @if (insightLayers.length > 0) {
+                <div class="insights-document-wrapper" id="insightsDocumentWrapper">
+                  <!-- TOC Sidebar -->
+                  <nav class="insights-toc" id="insightsToc">
+                    <div class="insights-toc-title">Contents</div>
+                    @if (reportData) {
+                      <a class="insights-toc-item"
+                        [class.active]="activeTocSection === 'report-summary'"
+                        (click)="scrollToSection('report-summary', $event)">
+                        <i class="bi bi-speedometer2"></i> Summary
+                      </a>
+                    }
+                    @for (layer of insightLayers; track layer; let i = $index) {
+                      <a
+                        class="insights-toc-item"
+                        [class.active]="activeTocSection === 'layer-' + layer.subtype"
+                        (click)="scrollToSection('layer-' + layer.subtype, $event)">
+                        <span class="insights-toc-num">{{ i + 1 }}</span>
+                        {{ getInsightLabel(layer.subtype) }}
+                        @if (getLayerRating(layer.subtype); as rating) {
+                          <span class="insights-toc-rating">
+                            {{ getStarRating(rating) }}
+                          </span>
+                        }
+                      </a>
+                    }
+                    <a class="insights-toc-item"
+                      [class.active]="activeTocSection === 'insights-methodology'"
+                      (click)="scrollToSection('insights-methodology', $event)">
+                      <i class="bi bi-info-circle"></i> Methodology
+                    </a>
+                  </nav>
+                  <!-- Content Area -->
+                  <div class="insights-content-area" id="insightsContentArea" (scroll)="onInsightsScroll($event)">
+                    <!-- Tech Stack Summary Bar -->
+                    @if (techStackSummary?.length) {
+                      <div style="display:flex;flex-wrap:wrap;gap:0.5rem;margin-bottom:1.5rem">
+                        @for (tech of techStackSummary; track tech) {
+                          <span class="badge badge-primary" style="font-size:var(--font-xs)">{{ tech }}</span>
+                        }
+                      </div>
+                    }
+                    <!-- Health Score Header -->
+                    <div class="insights-section" id="report-summary">
+                      <!-- No report yet -->
+                      @if (!reportData) {
+                        <div style="text-align:center;padding:1.5rem;background:var(--background-alt);border-radius:var(--radius-lg);margin-bottom:1.5rem">
+                          <div style="font-size:var(--font-sm);color:var(--text-muted);margin-bottom:0.75rem">
+                            <i class="bi bi-bar-chart"></i> Health score and ratings available after generating a report.
+                          </div>
+                          <button class="btn btn-secondary btn-sm" (click)="activeTab = 'Report'" style="font-size:var(--font-xs)">
+                            Go to Report tab to generate
+                          </button>
+                        </div>
+                      }
+                      @if (reportData) {
+                        <div>
+                          <div class="insights-health-header">
+                            <div class="insights-health-score"
+                              [style.borderColor]="reportData.overallHealthScore >= 70 ? 'var(--success)' : reportData.overallHealthScore >= 40 ? '#e6a700' : 'var(--danger)'">
+                              <div class="insights-health-number"
+                                [style.color]="reportData.overallHealthScore >= 70 ? 'var(--success)' : reportData.overallHealthScore >= 40 ? '#e6a700' : 'var(--danger)'">
+                                {{ reportData.overallHealthScore }}
+                              </div>
+                              <div class="insights-health-label">Health Score</div>
+                              @if (reportData.overallHealthScore != null) {
+                                <div class="insights-health-stars">
+                                  {{ getStarRating(Math.round(reportData.overallHealthScore / 20)) }}
+                                </div>
+                              }
+                              <span class="report-info-icon report-info-below" data-tooltip="Weighted average: Maturity (40%) + Quality (40%) + (5 - Risk)/5 (20%). Scale 0-100." style="margin-top:0.25rem"><i class="bi bi-info-circle"></i></span>
+                            </div>
+                            <div class="insights-health-details">
+                              <!-- Star Ratings Summary -->
+                              @if (reportData.layers?.length) {
+                                <div class="insights-ratings-summary">
+                                  @for (lr of reportData.layers; track lr) {
+                                    <div class="insights-rating-row">
+                                      <span class="insights-rating-label">{{ getInsightLabel(lr.subtype) }}</span>
+                                      <span class="insights-rating-stars">{{ getStarRating(lr.qualityRating) }}</span>
+                                      <span class="insights-rating-value">{{ lr.qualityRating }}/5</span>
+                                    </div>
+                                  }
+                                </div>
+                              }
+                            </div>
+                          </div>
+                          <!-- Velocity Metrics -->
+                          @if (reportData.velocity) {
+                            <div class="insights-velocity-row">
+                              <div class="insights-velocity-item">
+                                <div class="insights-velocity-value">{{ reportData.velocity.commitsPerMonth }}</div>
+                                <div class="insights-velocity-label">Commits/Month</div>
+                                <span class="report-info-icon report-info-below" data-tooltip="Total commits divided by the repository's active period in months." style="margin-top:0.25rem"><i class="bi bi-info-circle"></i></span>
+                              </div>
+                              <div class="insights-velocity-item">
+                                <div class="insights-velocity-value">{{ reportData.velocity.activeContributors }}</div>
+                                <div class="insights-velocity-label">Contributors</div>
+                                <span class="report-info-icon report-info-below" data-tooltip="Unique committer emails across all indexed commits." style="margin-top:0.25rem"><i class="bi bi-info-circle"></i></span>
+                              </div>
+                              <div class="insights-velocity-item">
+                                <div class="insights-velocity-value" style="text-transform:capitalize">{{ reportData.velocity.trend }}</div>
+                                <div class="insights-velocity-label">Trend</div>
+                                <span class="report-info-icon report-info-below" data-tooltip="Compares commit rate in the second half vs first half. Increasing if >20% higher, decreasing if >20% lower." style="margin-top:0.25rem"><i class="bi bi-info-circle"></i></span>
+                              </div>
+                            </div>
+                          }
+                          <!-- Top Contributors -->
+                          @if (reportData.velocity?.topContributors?.length) {
+                            <div style="margin-bottom:1.5rem;padding:0 0.5rem">
+                              <div style="font-weight:600;font-size:var(--font-xs);margin-bottom:0.5rem;color:var(--text-muted)">Top Contributors</div>
+                              <div style="display:flex;flex-wrap:wrap;gap:0.5rem">
+                                @for (c of reportData.velocity.topContributors; track c) {
+                                  <span style="display:inline-flex;align-items:center;gap:0.375rem;padding:0.25rem 0.625rem;background:var(--background-alt);border-radius:100px;font-size:var(--font-xs)">
+                                    <strong>{{ c.name }}</strong>
+                                    <span class="text-muted" style="font-size:0.85em;opacity:0.7">{{ c.email }}</span>
+                                    <span class="text-muted">{{ c.commits }}</span>
+                                  </span>
+                                }
+                              </div>
+                            </div>
+                          }
+                          <!-- Top 5 Improvements -->
+                          @if (reportData.top5Improvements?.length) {
+                            <div class="insights-improvements">
+                              <h3 class="insights-improvements-title">
+                                <i class="bi bi-arrow-up-circle"></i> Top Improvements
+                              </h3>
+                              @for (imp of reportData.top5Improvements; track imp; let i = $index) {
+                                <div class="insights-improvement-item">
+                                  <span class="insights-improvement-num">{{ i + 1 }}</span>
+                                  <div class="insights-improvement-body">
+                                    <div class="insights-improvement-title">{{ imp.title }}</div>
+                                    @if (imp.description) {
+                                      <div class="insights-improvement-desc">{{ imp.description }}</div>
+                                    }
+                                  </div>
+                                  <span class="badge insights-impact-badge"
+                                    [ngClass]="imp.impact === 'high' || imp.impact === 'critical' ? 'badge-danger' : imp.impact === 'medium' ? 'badge-warning' : 'badge-info'"
+                                  style="font-size:0.6875rem;text-transform:capitalize">{{ imp.impact }}</span>
+                                </div>
+                              }
+                            </div>
+                          }
+                        </div>
+                        }<!-- end *ngIf="reportData" -->
+                      </div><!-- end insights-section report-summary -->
+                      <!-- Each Insight Layer Section -->
+                      @for (layer of insightLayers; track layer; let idx = $index) {
+                        <div
+                          class="insights-section insights-layer-section"
+                          [id]="'layer-' + layer.subtype">
+                          <!-- Section Heading -->
+                          <div class="insights-layer-heading">
+                            <div class="insights-layer-heading-left">
+                              <span class="insights-layer-num">{{ idx + 1 }}</span>
+                              <h2 class="insights-layer-title">{{ getInsightLabel(layer.subtype) }}</h2>
+                            </div>
+                            @if (getLayerRating(layer.subtype); as rating) {
+                              <div class="insights-layer-stars">
+                                {{ getStarRating(rating) }}
+                              </div>
+                            }
+                          </div>
+                          <!-- Ratings Badges -->
+                          @if (getLayerReport(layer.subtype); as lr) {
+                            <div class="insights-layer-badges">
+                              <span class="badge insights-badge-maturity"
+                                [ngClass]="lr.maturityRating >= 4 ? 'badge-success' : lr.maturityRating >= 3 ? 'badge-warning' : 'badge-danger'">
+                                <i class="bi bi-bar-chart-fill"></i> Maturity {{ lr.maturityRating }}/5
+                                <span class="report-info-icon report-info-inline report-info-below" data-tooltip="1=Initial, 2=Developing, 3=Defined, 4=Managed, 5=Optimized"><i class="bi bi-info-circle"></i></span>
+                              </span>
+                              <span class="badge insights-badge-quality"
+                                [ngClass]="lr.qualityRating >= 4 ? 'badge-success' : lr.qualityRating >= 3 ? 'badge-warning' : 'badge-danger'">
+                                <i class="bi bi-star-fill"></i> Quality {{ lr.qualityRating }}/5
+                                <span class="report-info-icon report-info-inline report-info-below" data-tooltip="1=Poor, 2=Fair, 3=Good, 4=Very Good, 5=Excellent"><i class="bi bi-info-circle"></i></span>
+                              </span>
+                              <span class="badge insights-badge-risk"
+                                [ngClass]="lr.riskRating <= 2 ? 'badge-success' : lr.riskRating <= 3 ? 'badge-warning' : 'badge-danger'">
+                                <i class="bi bi-shield-fill"></i> Risk {{ lr.riskRating }}/5
+                                <span class="report-info-icon report-info-inline report-info-below" data-tooltip="1=Low, 2=Minor, 3=Moderate, 4=Significant, 5=Critical"><i class="bi bi-info-circle"></i></span>
+                              </span>
+                            </div>
+                          }
+                          <!-- Strengths / Weaknesses / Recommendations -->
+                          @if (getLayerReport(layer.subtype); as lr) {
+                            <div class="insights-layer-meta">
+                              <div class="insights-meta-block">
+                                <div class="insights-meta-title insights-meta-strengths"><i class="bi bi-check-circle-fill"></i> Strengths</div>
+                                @if (lr.strengths?.length) {
+                                  <ul class="insights-meta-list">
+                                    @for (s of lr.strengths; track s) {
+                                      <li class="insights-strength-item">{{ s }}</li>
+                                    }
+                                  </ul>
+                                }
+                                @if (!lr.strengths?.length) {
+                                  <div class="text-muted" style="font-size:var(--font-xs);padding:0.25rem 0">Generate report to see ratings</div>
+                                }
+                              </div>
+                              <div class="insights-meta-block">
+                                <div class="insights-meta-title insights-meta-weaknesses"><i class="bi bi-exclamation-triangle-fill"></i> Weaknesses</div>
+                                @if (lr.weaknesses?.length) {
+                                  <ul class="insights-meta-list">
+                                    @for (w of lr.weaknesses; track w) {
+                                      <li class="insights-weakness-item">{{ w }}</li>
+                                    }
+                                  </ul>
+                                }
+                                @if (!lr.weaknesses?.length) {
+                                  <div class="text-muted" style="font-size:var(--font-xs);padding:0.25rem 0">Generate report to see ratings</div>
+                                }
+                              </div>
+                              <div class="insights-meta-block">
+                                <div class="insights-meta-title insights-meta-recommendations"><i class="bi bi-arrow-right-circle-fill"></i> Recommendations</div>
+                                @if (lr.recommendations?.length) {
+                                  <ul class="insights-meta-list">
+                                    @for (r of lr.recommendations; track r) {
+                                      <li class="insights-recommendation-item">{{ r }}</li>
+                                    }
+                                  </ul>
+                                }
+                                @if (!lr.recommendations?.length) {
+                                  <div class="text-muted" style="font-size:var(--font-xs);padding:0.25rem 0">Generate report to see recommendations</div>
+                                }
+                              </div>
+                            </div>
+                          }
+                          <!-- Rendered Markdown Content -->
+                          <div class="insights-layer-content" [innerHTML]="renderInsightHtml(layer)"></div>
+                        </div>
+                      }
+                      <!-- Methodology -->
+                      <div class="insights-section report-methodology-section" id="insights-methodology" style="margin-top:2rem">
+                        <h2 class="report-section-title">
+                          <i class="bi bi-info-circle"></i> Methodology
+                        </h2>
+                        <div class="report-methodology-toggle" (click)="showInsightsMethodology = !showInsightsMethodology">
+                          <i class="bi" [ngClass]="showInsightsMethodology ? 'bi-chevron-up' : 'bi-chevron-down'"></i>
+                          {{ showInsightsMethodology ? 'Hide methodology details' : 'Show methodology details' }}
+                        </div>
+                        <div class="report-methodology-content" [class.report-methodology-expanded]="showInsightsMethodology">
+                          <div class="report-methodology-grid">
+                            <div class="report-methodology-item">
+                              <div class="report-methodology-term">Health Score</div>
+                              <div class="report-methodology-def">Weighted average: Maturity (40%) + Quality (40%) + (5 - Risk)/5 (20%). Scale 0-100.</div>
+                            </div>
+                            <div class="report-methodology-item">
+                              <div class="report-methodology-term">Commits/Month</div>
+                              <div class="report-methodology-def">Total commits divided by the repository's active period in months.</div>
+                            </div>
+                            <div class="report-methodology-item">
+                              <div class="report-methodology-term">Active Contributors</div>
+                              <div class="report-methodology-def">Unique committer emails across all indexed commits.</div>
+                            </div>
+                            <div class="report-methodology-item">
+                              <div class="report-methodology-term">Trend</div>
+                              <div class="report-methodology-def">Compares commit rate in the second half of the repo's history vs the first half. Increasing if >20% higher, decreasing if >20% lower.</div>
+                            </div>
+                            <div class="report-methodology-item">
+                              <div class="report-methodology-term">Maturity Rating</div>
+                              <div class="report-methodology-def">1=Initial, 2=Developing, 3=Defined, 4=Managed, 5=Optimized.</div>
+                            </div>
+                            <div class="report-methodology-item">
+                              <div class="report-methodology-term">Quality Rating</div>
+                              <div class="report-methodology-def">1=Poor, 2=Fair, 3=Good, 4=Very Good, 5=Excellent.</div>
+                            </div>
+                            <div class="report-methodology-item">
+                              <div class="report-methodology-term">Risk Rating</div>
+                              <div class="report-methodology-def">1=Low, 2=Minor, 3=Moderate, 4=Significant, 5=Critical.</div>
+                            </div>
+                            <div class="report-methodology-item">
+                              <div class="report-methodology-term">Impact / Effort</div>
+                              <div class="report-methodology-def">Impact: expected improvement. Effort: implementation cost. Both rated high/medium/low.</div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div><!-- End Content Area -->
+                  </div>
+                  }<!-- End Document Wrapper -->
+                </div>
+                }<!-- End Insights Tab -->
+                <!-- Report Tab -->
+                @if (activeTab === 'Report') {
+                  <div class="report-tab">
+                    <!-- Toolbar -->
+                    <div class="report-toolbar">
+                      <div class="report-toolbar-left">
+                        <i class="bi bi-file-earmark-bar-graph" style="font-size:1.125rem;color:var(--primary)"></i>
+                        <span style="font-weight:600;font-size:var(--font-sm)">Repository Report</span>
+                      </div>
+                      <div class="report-toolbar-right">
+                        <button class="btn btn-primary btn-sm" (click)="generateReport()" [disabled]="generatingReport || !insightLayers.length">
+                          <i class="bi bi-file-earmark-bar-graph"></i> {{ generatingReport ? 'Generating...' : (reportData ? 'Regenerate Report' : 'Generate Report') }}
+                        </button>
+                        @if (reportData) {
+                          <button (click)="exportHtml()" class="btn btn-secondary btn-sm">
+                            <i class="bi bi-download"></i> Export HTML
+                          </button>
+                        }
+                        @if (reportData) {
+                          <button (click)="exportPdf()" class="btn btn-secondary btn-sm">
+                            <i class="bi bi-file-earmark-pdf"></i> Save as PDF
+                          </button>
+                        }
+                        @if (!insightLayers.length) {
+                          <span class="text-muted" style="font-size:var(--font-xs);align-self:center">Generate insights first.</span>
+                        }
+                      </div>
+                    </div>
+                    <!-- Empty state -->
+                    @if (!reportData && !generatingReport) {
+                      <div class="report-empty card">
+                        <i class="bi bi-file-earmark-bar-graph" style="font-size:2.5rem;color:var(--text-light);margin-bottom:1rem;display:block"></i>
+                        <h3 style="font-size:var(--font-lg);margin-bottom:0.5rem">No report yet</h3>
+                        <p class="text-muted" style="font-size:var(--font-xs);margin-bottom:1.25rem">Generate insights first, then click "Generate Report" to produce a comprehensive analysis.</p>
+                        @if (reportError) {
+                          <div style="margin-bottom:1rem;padding:0.75rem 1rem;background:rgba(220,53,69,0.08);border:1px solid rgba(220,53,69,0.2);border-radius:var(--radius);color:var(--danger);font-size:var(--font-xs)">
+                            <i class="bi bi-exclamation-triangle"></i> {{ reportError }}
+                          </div>
+                        }
+                        <button class="btn btn-primary" (click)="generateReport()" [disabled]="generatingReport || !insightLayers.length">
+                          <i class="bi bi-file-earmark-bar-graph"></i> Generate Report
+                        </button>
+                      </div>
+                    }
+                    <!-- Report document with TOC sidebar -->
+                    @if (reportData) {
+                      <div class="report-document-wrapper" id="reportDocumentWrapper">
+                        <!-- TOC Sidebar -->
+                        <nav class="report-toc" id="reportToc">
+                          <div class="report-toc-title">Contents</div>
+                          <a class="report-toc-item"
+                            [class.active]="activeReportSection === 'rpt-health'"
+                            (click)="scrollToReportSection('rpt-health', $event)">
+                            <span class="report-toc-score"
+                              [style.background]="reportData.overallHealthScore >= 70 ? 'var(--success)' : reportData.overallHealthScore >= 40 ? '#e6a700' : 'var(--danger)'">
+                              {{ reportData.overallHealthScore }}
+                            </span>
+                            Health Score
+                          </a>
+                          <a class="report-toc-item"
+                            [class.active]="activeReportSection === 'rpt-velocity'"
+                            (click)="scrollToReportSection('rpt-velocity', $event)">
+                            <i class="bi bi-speedometer2"></i> Velocity
+                          </a>
+                          <a class="report-toc-item"
+                            [class.active]="activeReportSection === 'rpt-layers-overview'"
+                            (click)="scrollToReportSection('rpt-layers-overview', $event)">
+                            <i class="bi bi-grid"></i> Layer Overview
+                          </a>
+                          @if (reportData.top5Improvements?.length) {
+                            <a class="report-toc-item"
+                              [class.active]="activeReportSection === 'rpt-improvements'"
+                              (click)="scrollToReportSection('rpt-improvements', $event)">
+                              <i class="bi bi-arrow-up-circle"></i> Top Improvements
+                            </a>
+                          }
+                          <div class="report-toc-divider"></div>
+                          @for (layer of reportData.layers; track layer; let i = $index) {
+                            <a class="report-toc-item"
+                              [class.active]="activeReportSection === 'rpt-layer-' + layer.subtype"
+                              (click)="scrollToReportSection('rpt-layer-' + layer.subtype, $event)">
+                              <span class="report-toc-num">{{ i + 1 }}</span>
+                              {{ getInsightLabel(layer.subtype) || layer.name }}
+                              <span class="report-toc-rating">{{ getStarRating(layer.qualityRating) }}</span>
+                            </a>
+                          }
+                          <div class="report-toc-divider"></div>
+                          <a class="report-toc-item"
+                            [class.active]="activeReportSection === 'rpt-methodology'"
+                            (click)="scrollToReportSection('rpt-methodology', $event)">
+                            <i class="bi bi-info-circle"></i> Methodology
+                          </a>
+                        </nav>
+                        <!-- Content Area (single scrollable document) -->
+                        <div class="report-content-area" id="reportContentArea" (scroll)="onReportScroll($event)">
+                          <!-- Tech Stack Summary Bar -->
+                          @if (techStackSummary?.length) {
+                            <div style="display:flex;flex-wrap:wrap;gap:0.5rem;margin-bottom:1.5rem">
+                              @for (tech of techStackSummary; track tech) {
+                                <span class="badge badge-primary" style="font-size:var(--font-xs)">{{ tech }}</span>
+                              }
+                            </div>
+                          }
+                          <!-- Section 1: Health Score -->
+                          <section class="report-section" id="rpt-health">
+                            <div class="report-health-header">
+                              <div class="report-health-score-ring"
+                                [style.borderColor]="reportData.overallHealthScore >= 70 ? 'var(--success)' : reportData.overallHealthScore >= 40 ? '#e6a700' : 'var(--danger)'">
+                                <div class="report-health-number"
+                                  [style.color]="reportData.overallHealthScore >= 70 ? 'var(--success)' : reportData.overallHealthScore >= 40 ? '#e6a700' : 'var(--danger)'">
+                                  {{ reportData.overallHealthScore }}
+                                </div>
+                                <div class="report-health-of">/100</div>
+                                <div class="report-health-label">Health Score</div>
+                                <span class="report-info-icon" data-tooltip="Weighted average: Maturity (40%) + Quality (40%) + (5 - Risk)/5 (20%). Scale 0-100.">
+                                  <i class="bi bi-info-circle"></i>
+                                </span>
+                              </div>
+                              @if (reportData.overallHealthScore != null) {
+                                <div class="report-health-stars">
+                                  {{ getStarRating(Math.round(reportData.overallHealthScore / 20)) }}
+                                </div>
+                              }
+                            </div>
+                            <!-- Ratings summary grid -->
+                            @if (reportData.layers?.length) {
+                              <div class="report-ratings-grid">
+                                @for (lr of reportData.layers; track lr) {
+                                  <div class="report-rating-row">
+                                    <span class="report-rating-label">{{ getInsightLabel(lr.subtype) }}</span>
+                                    <span class="report-rating-stars">{{ getStarRating(lr.qualityRating) }}</span>
+                                    <span class="report-rating-value">{{ lr.qualityRating }}/5</span>
+                                  </div>
+                                }
+                              </div>
+                            }
+                          </section>
+                          <!-- Section 2: Velocity Metrics -->
+                          @if (reportData.velocity) {
+                            <section class="report-section" id="rpt-velocity">
+                              <h2 class="report-section-title">
+                                <i class="bi bi-speedometer2"></i> Velocity Metrics
+                              </h2>
+                              <div class="report-velocity-grid">
+                                <div class="report-velocity-card">
+                                  <div class="report-velocity-value">{{ reportData.velocity.commitsPerMonth }}</div>
+                                  <div class="report-velocity-label">
+                                    Commits/Month
+                                    <span class="report-info-icon" data-tooltip="Total commits divided by the repository's active period in months.">
+                                      <i class="bi bi-info-circle"></i>
+                                    </span>
+                                  </div>
+                                </div>
+                                <div class="report-velocity-card">
+                                  <div class="report-velocity-value">{{ reportData.velocity.activeContributors }}</div>
+                                  <div class="report-velocity-label">
+                                    Active Contributors
+                                    <span class="report-info-icon" data-tooltip="Unique committer emails across all indexed commits.">
+                                      <i class="bi bi-info-circle"></i>
+                                    </span>
+                                  </div>
+                                </div>
+                                <div class="report-velocity-card">
+                                  <div class="report-velocity-value report-velocity-trend" style="text-transform:capitalize">{{ reportData.velocity.trend }}</div>
+                                  <div class="report-velocity-label">
+                                    Trend
+                                    <span class="report-info-icon" data-tooltip="Compares commit rate in the second half of the repo's history vs the first half. Increasing if >20% higher, decreasing if >20% lower.">
+                                      <i class="bi bi-info-circle"></i>
+                                    </span>
+                                  </div>
+                                </div>
+                                @if (reportData.velocity.averageCommitsPerDay != null) {
+                                  <div class="report-velocity-card">
+                                    <div class="report-velocity-value">{{ reportData.velocity.averageCommitsPerDay | number:'1.1-1' }}</div>
+                                    <div class="report-velocity-label">Commits/Day</div>
+                                  </div>
+                                }
+                                @if (reportData.velocity.deployFrequency) {
+                                  <div class="report-velocity-card">
+                                    <div class="report-velocity-value">{{ reportData.velocity.deployFrequency }}</div>
+                                    <div class="report-velocity-label">Deploy Frequency</div>
+                                  </div>
+                                }
+                              </div>
+                              <!-- Top Contributors -->
+                              @if (reportData.velocity?.topContributors?.length) {
+                                <div style="margin-top:1.25rem">
+                                  <div style="font-weight:600;font-size:var(--font-xs);margin-bottom:0.5rem;color:var(--text-muted)">Top Contributors</div>
+                                  <div style="display:flex;flex-wrap:wrap;gap:0.5rem">
+                                    @for (c of reportData.velocity.topContributors; track c) {
+                                      <span style="display:inline-flex;align-items:center;gap:0.375rem;padding:0.25rem 0.625rem;background:var(--background-alt);border-radius:100px;font-size:var(--font-xs)">
+                                        <strong>{{ c.name }}</strong>
+                                        <span class="text-muted" style="font-size:0.85em;opacity:0.7">{{ c.email }}</span>
+                                        <span class="text-muted">{{ c.commits }}</span>
+                                      </span>
+                                    }
+                                  </div>
+                                </div>
+                              }
+                            </section>
+                          }
+                          <!-- Section 3: Layer Overview Grid -->
+                          <section class="report-section" id="rpt-layers-overview">
+                            <h2 class="report-section-title">
+                              <i class="bi bi-grid"></i> Layer Overview
+                            </h2>
+                            <div class="report-layer-overview-grid">
+                              @for (layer of reportData.layers; track layer) {
+                                <div class="report-layer-card"
+                                  (click)="scrollToReportSection('rpt-layer-' + layer.subtype, $event)">
+                                  <div class="report-layer-card-header">
+                                    <span class="report-layer-card-name">{{ getInsightLabel(layer.subtype) || layer.name }}</span>
+                                    <span class="report-layer-card-stars">{{ getStarRating(layer.qualityRating) }}</span>
+                                  </div>
+                                  <div class="report-layer-card-badges">
+                                    <span class="report-mini-badge"
+                                      [ngClass]="layer.maturityRating >= 4 ? 'mini-success' : layer.maturityRating >= 3 ? 'mini-warning' : 'mini-danger'">
+                                      M:{{ layer.maturityRating }}
+                                    </span>
+                                    <span class="report-mini-badge"
+                                      [ngClass]="layer.qualityRating >= 4 ? 'mini-success' : layer.qualityRating >= 3 ? 'mini-warning' : 'mini-danger'">
+                                      Q:{{ layer.qualityRating }}
+                                    </span>
+                                    <span class="report-mini-badge"
+                                      [ngClass]="layer.riskRating <= 2 ? 'mini-success' : layer.riskRating <= 3 ? 'mini-warning' : 'mini-danger'">
+                                      R:{{ layer.riskRating }}
+                                    </span>
+                                  </div>
+                                </div>
+                              }
+                            </div>
+                          </section>
+                          <!-- Section 4: Top Improvements -->
+                          @if (reportData.top5Improvements?.length) {
+                            <section class="report-section" id="rpt-improvements">
+                              <h2 class="report-section-title">
+                                <i class="bi bi-arrow-up-circle"></i> Top Improvements
+                              </h2>
+                              <div class="report-improvements-list">
+                                @for (imp of reportData.top5Improvements; track imp; let i = $index) {
+                                  <div class="report-improvement-item">
+                                    <span class="report-improvement-num">{{ i + 1 }}</span>
+                                    <div class="report-improvement-body">
+                                      <div class="report-improvement-title">{{ imp.title }}</div>
+                                      @if (imp.description) {
+                                        <div class="report-improvement-desc">{{ imp.description }}</div>
+                                      }
+                                      <div class="report-improvement-badges">
+                                        <span class="badge"
+                                          [ngClass]="imp.impact === 'high' || imp.impact === 'critical' ? 'badge-danger' : imp.impact === 'medium' ? 'badge-warning' : 'badge-muted'"
+                                          style="font-size:0.6875rem;text-transform:capitalize">
+                                          {{ imp.impact }} impact
+                                          <span class="report-info-icon" data-tooltip="Impact: expected improvement. Effort: implementation cost. Both rated high/medium/low.">
+                                            <i class="bi bi-info-circle"></i>
+                                          </span>
+                                        </span>
+                                        <span class="badge badge-muted" style="font-size:0.6875rem;text-transform:capitalize">{{ imp.effort }} effort</span>
+                                        @if (imp.layer) {
+                                          <span class="badge badge-muted" style="font-size:0.6875rem">{{ getInsightLabel(imp.layer) || imp.layer }}</span>
+                                        }
+                                      </div>
+                                    </div>
+                                  </div>
+                                }
+                              </div>
+                            </section>
+                          }
+                          <!-- Section 5+: Each Layer Section (all rendered, not toggled) -->
+                          @for (layer of reportData.layers; track layer; let idx = $index) {
+                            <section
+                              class="report-section report-layer-section"
+                              [id]="'rpt-layer-' + layer.subtype">
+                              <!-- Section Heading -->
+                              <div class="report-layer-heading">
+                                <div class="report-layer-heading-left">
+                                  <span class="report-layer-num">{{ idx + 1 }}</span>
+                                  <h2 class="report-layer-title">{{ getInsightLabel(layer.subtype) || layer.name }}</h2>
+                                </div>
+                                <div class="report-layer-heading-stars">
+                                  {{ getStarRating(layer.qualityRating) }}
+                                </div>
+                              </div>
+                              <!-- Rating Badges -->
+                              <div class="report-layer-badges">
+                                <span class="badge report-badge-maturity"
+                                  [ngClass]="layer.maturityRating >= 4 ? 'badge-success' : layer.maturityRating >= 3 ? 'badge-warning' : 'badge-danger'">
+                                  <i class="bi bi-bar-chart-fill"></i> Maturity {{ layer.maturityRating }}/5
+                                  <span class="report-info-icon report-info-inline" data-tooltip="1=Initial, 2=Developing, 3=Defined, 4=Managed, 5=Optimized.">
+                                    <i class="bi bi-info-circle"></i>
+                                  </span>
+                                </span>
+                                <span class="badge report-badge-quality"
+                                  [ngClass]="layer.qualityRating >= 4 ? 'badge-success' : layer.qualityRating >= 3 ? 'badge-warning' : 'badge-danger'">
+                                  <i class="bi bi-star-fill"></i> Quality {{ layer.qualityRating }}/5
+                                  <span class="report-info-icon report-info-inline" data-tooltip="1=Poor, 2=Fair, 3=Good, 4=Very Good, 5=Excellent.">
+                                    <i class="bi bi-info-circle"></i>
+                                  </span>
+                                </span>
+                                <span class="badge report-badge-risk"
+                                  [ngClass]="layer.riskRating <= 2 ? 'badge-success' : layer.riskRating <= 3 ? 'badge-warning' : 'badge-danger'">
+                                  <i class="bi bi-shield-fill"></i> Risk {{ layer.riskRating }}/5
+                                  <span class="report-info-icon report-info-inline" data-tooltip="1=Low, 2=Minor, 3=Moderate, 4=Significant, 5=Critical.">
+                                    <i class="bi bi-info-circle"></i>
+                                  </span>
+                                </span>
+                              </div>
+                              <!-- Strengths / Weaknesses / Recommendations -->
+                              <div class="report-layer-meta">
+                                @if (layer.strengths?.length) {
+                                  <div class="report-meta-block">
+                                    <div class="report-meta-title report-meta-strengths"><i class="bi bi-check-circle-fill"></i> Strengths</div>
+                                    <ul class="report-meta-list">
+                                      @for (s of layer.strengths; track s) {
+                                        <li class="report-strength-item">{{ s }}</li>
+                                      }
+                                    </ul>
+                                  </div>
+                                }
+                                @if (layer.weaknesses?.length) {
+                                  <div class="report-meta-block">
+                                    <div class="report-meta-title report-meta-weaknesses"><i class="bi bi-exclamation-triangle-fill"></i> Weaknesses</div>
+                                    <ul class="report-meta-list">
+                                      @for (w of layer.weaknesses; track w) {
+                                        <li class="report-weakness-item">{{ w }}</li>
+                                      }
+                                    </ul>
+                                  </div>
+                                }
+                                @if (layer.recommendations?.length) {
+                                  <div class="report-meta-block report-meta-block-full">
+                                    <div class="report-meta-title report-meta-recommendations"><i class="bi bi-arrow-right-circle-fill"></i> Recommendations</div>
+                                    <ul class="report-meta-list">
+                                      @for (r of layer.recommendations; track r) {
+                                        <li class="report-recommendation-item">{{ r }}</li>
+                                      }
+                                    </ul>
+                                  </div>
+                                }
+                              </div>
+                            </section>
+                          }
+                          <!-- Methodology Section -->
+                          <section class="report-section report-methodology-section" id="rpt-methodology">
+                            <h2 class="report-section-title">
+                              <i class="bi bi-info-circle"></i> Methodology
+                            </h2>
+                            <div class="report-methodology-toggle" (click)="showMethodology = !showMethodology">
+                              <i class="bi" [ngClass]="showMethodology ? 'bi-chevron-up' : 'bi-chevron-down'"></i>
+                              {{ showMethodology ? 'Hide methodology details' : 'Show methodology details' }}
+                            </div>
+                            <div class="report-methodology-content" [class.report-methodology-expanded]="showMethodology">
+                              <div class="report-methodology-grid">
+                                <div class="report-methodology-item">
+                                  <div class="report-methodology-term">Health Score</div>
+                                  <div class="report-methodology-def">Weighted average: Maturity (40%) + Quality (40%) + (5 - Risk)/5 (20%). Scale 0-100.</div>
+                                </div>
+                                <div class="report-methodology-item">
+                                  <div class="report-methodology-term">Commits/Month</div>
+                                  <div class="report-methodology-def">Total commits divided by the repository's active period in months.</div>
+                                </div>
+                                <div class="report-methodology-item">
+                                  <div class="report-methodology-term">Active Contributors</div>
+                                  <div class="report-methodology-def">Unique committer emails across all indexed commits.</div>
+                                </div>
+                                <div class="report-methodology-item">
+                                  <div class="report-methodology-term">Trend</div>
+                                  <div class="report-methodology-def">Compares commit rate in the second half of the repo's history vs the first half. Increasing if >20% higher, decreasing if >20% lower.</div>
+                                </div>
+                                <div class="report-methodology-item">
+                                  <div class="report-methodology-term">Maturity Rating</div>
+                                  <div class="report-methodology-def">1=Initial, 2=Developing, 3=Defined, 4=Managed, 5=Optimized.</div>
+                                </div>
+                                <div class="report-methodology-item">
+                                  <div class="report-methodology-term">Quality Rating</div>
+                                  <div class="report-methodology-def">1=Poor, 2=Fair, 3=Good, 4=Very Good, 5=Excellent.</div>
+                                </div>
+                                <div class="report-methodology-item">
+                                  <div class="report-methodology-term">Risk Rating</div>
+                                  <div class="report-methodology-def">1=Low, 2=Minor, 3=Moderate, 4=Significant, 5=Critical.</div>
+                                </div>
+                                <div class="report-methodology-item">
+                                  <div class="report-methodology-term">Impact / Effort</div>
+                                  <div class="report-methodology-def">Impact: expected improvement. Effort: implementation cost. Both rated high/medium/low.</div>
+                                </div>
+                              </div>
+                            </div>
+                          </section>
+                        </div><!-- End Content Area -->
+                      </div>
+                      }<!-- End Document Wrapper -->
+                    </div>
+                    }<!-- End Report Tab -->
+                    <!-- History Tab -->
+                    @if (activeTab === 'History') {
+                      <div>
+                        <app-repository-history [repositoryId]="repo.id" [ref]="selectedRef" style="display:block" />
+                      </div>
+                    }
+                    <!-- Analytics Tab -->
+                    @if (activeTab === 'Analytics') {
+                      <div>
+                        <app-repository-analytics [repositoryId]="repo.id" />
+                      </div>
+                    }
+                  </div>
+                }
+    
+                @if (!loading && !repo) {
+                  <div class="empty-state card">
+                    <i class="bi bi-exclamation-circle"></i>
+                    <h3>Repository not found</h3>
+                    <a routerLink="/repositories" class="btn btn-primary mt-2">Back to Repositories</a>
+                  </div>
+                }
+    `,
   encapsulation: ViewEncapsulation.None,
   styles: [`
     .detail-row { display: flex; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid var(--border); }

--- a/client/src/app/components/repositories/repository-history.component.ts
+++ b/client/src/app/components/repositories/repository-history.component.ts
@@ -35,68 +35,102 @@ interface GitLogCommit {
   imports: [CommonModule],
   template: `
     <!-- Git Commits (filtered by branch) -->
-    <div class="card" *ngIf="gitCommits.length > 0" style="margin-bottom:1.5rem">
-      <h3 style="margin-bottom:1rem;font-size:1rem">
-        Commits
-        <span *ngIf="ref" class="badge badge-primary" style="font-size:0.75rem;margin-left:0.5rem">{{ ref }}</span>
-      </h3>
-      <div class="commit-item" *ngFor="let commit of gitCommits">
-        <div style="display:flex;justify-content:space-between;align-items:center">
-          <div style="flex:1;min-width:0">
-            <div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.25rem">
-              <code style="font-size:0.75rem;color:var(--primary);flex-shrink:0">{{ commit.abbreviatedSha }}</code>
-              <span *ngIf="commit.isIndexed" class="badge badge-success" style="font-size:0.625rem;flex-shrink:0">indexed</span>
-              <span *ngIf="commit.enrichmentCount > 0" class="badge badge-muted" style="font-size:0.625rem;flex-shrink:0">{{ commit.enrichmentCount }} enrichments</span>
-            </div>
-            <div style="font-size:0.8125rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ commit.message }}</div>
-            <div class="text-muted" style="font-size:0.75rem;margin-top:0.125rem">
-              {{ commit.authorName }} &middot; {{ commit.committedAt | date:'short' }}
+    @if (gitCommits.length > 0) {
+      <div class="card" style="margin-bottom:1.5rem">
+        <h3 style="margin-bottom:1rem;font-size:1rem">
+          Commits
+          @if (ref) {
+            <span class="badge badge-primary" style="font-size:0.75rem;margin-left:0.5rem">{{ ref }}</span>
+          }
+        </h3>
+        @for (commit of gitCommits; track commit) {
+          <div class="commit-item">
+            <div style="display:flex;justify-content:space-between;align-items:center">
+              <div style="flex:1;min-width:0">
+                <div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.25rem">
+                  <code style="font-size:0.75rem;color:var(--primary);flex-shrink:0">{{ commit.abbreviatedSha }}</code>
+                  @if (commit.isIndexed) {
+                    <span class="badge badge-success" style="font-size:0.625rem;flex-shrink:0">indexed</span>
+                  }
+                  @if (commit.enrichmentCount > 0) {
+                    <span class="badge badge-muted" style="font-size:0.625rem;flex-shrink:0">{{ commit.enrichmentCount }} enrichments</span>
+                  }
+                </div>
+                <div style="font-size:0.8125rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ commit.message }}</div>
+                <div class="text-muted" style="font-size:0.75rem;margin-top:0.125rem">
+                  {{ commit.authorName }} &middot; {{ commit.committedAt | date:'short' }}
+                </div>
+              </div>
             </div>
           </div>
-        </div>
+        }
+        @if (hasMoreCommits) {
+          <div style="text-align:center;padding:0.75rem 0">
+            <button class="btn btn-secondary btn-sm" (click)="loadMoreCommits()" [disabled]="loadingCommits" style="font-size:0.75rem">
+              {{ loadingCommits ? 'Loading...' : 'Load more' }}
+            </button>
+          </div>
+        }
       </div>
-      <div *ngIf="hasMoreCommits" style="text-align:center;padding:0.75rem 0">
-        <button class="btn btn-secondary btn-sm" (click)="loadMoreCommits()" [disabled]="loadingCommits" style="font-size:0.75rem">
-          {{ loadingCommits ? 'Loading...' : 'Load more' }}
-        </button>
+    }
+    @if (gitCommits.length === 0 && !loadingCommits && ref) {
+      <div class="card" style="margin-bottom:1.5rem">
+        <p class="text-muted" style="font-size:0.8125rem">No commits found for branch "{{ ref }}"</p>
       </div>
-    </div>
-    <div *ngIf="gitCommits.length === 0 && !loadingCommits && ref" class="card" style="margin-bottom:1.5rem">
-      <p class="text-muted" style="font-size:0.8125rem">No commits found for branch "{{ ref }}"</p>
-    </div>
-
+    }
+    
     <!-- Indexing History -->
-    <div class="card" *ngIf="runs.length > 0">
-      <h3 style="margin-bottom:1rem;font-size:1rem">Indexing History</h3>
-      <div class="run-item" *ngFor="let run of runs">
-        <div style="display:flex;justify-content:space-between;align-items:center">
-          <div>
-            <span class="badge" [ngClass]="run.status === 'completed' ? 'badge-success' : run.status === 'failed' ? 'badge-danger' : 'badge-info'">
-              {{ run.status }}
-            </span>
-            <span class="text-muted" style="margin-left:0.75rem;font-size:0.8125rem">
-              {{ run.startedAt | date:'short' }}
-            </span>
-            <span class="text-muted" style="margin-left:0.5rem;font-size:0.75rem" *ngIf="run.durationSeconds">
-              ({{ run.durationSeconds | number:'1.1-1' }}s)
-            </span>
+    @if (runs.length > 0) {
+      <div class="card">
+        <h3 style="margin-bottom:1rem;font-size:1rem">Indexing History</h3>
+        @for (run of runs; track run) {
+          <div class="run-item">
+            <div style="display:flex;justify-content:space-between;align-items:center">
+              <div>
+                <span class="badge" [ngClass]="run.status === 'completed' ? 'badge-success' : run.status === 'failed' ? 'badge-danger' : 'badge-info'">
+                  {{ run.status }}
+                </span>
+                <span class="text-muted" style="margin-left:0.75rem;font-size:0.8125rem">
+                  {{ run.startedAt | date:'short' }}
+                </span>
+                @if (run.durationSeconds) {
+                  <span class="text-muted" style="margin-left:0.5rem;font-size:0.75rem">
+                    ({{ run.durationSeconds | number:'1.1-1' }}s)
+                  </span>
+                }
+              </div>
+              @if (run.status === 'completed') {
+                <div class="stats">
+                  @if (run.snippetsAdded) {
+                    <span class="stat-badge added">+{{ run.snippetsAdded }}</span>
+                  }
+                  @if (run.snippetsUpdated) {
+                    <span class="stat-badge updated">~{{ run.snippetsUpdated }}</span>
+                  }
+                  @if (run.snippetsDeleted) {
+                    <span class="stat-badge deleted">-{{ run.snippetsDeleted }}</span>
+                  }
+                  @if (run.snippetsUnchanged) {
+                    <span class="stat-badge unchanged">={{ run.snippetsUnchanged }}</span>
+                  }
+                </div>
+              }
+            </div>
+            @if (run.errorMessage) {
+              <div style="color:var(--danger);font-size:0.8125rem;margin-top:0.25rem">
+                {{ run.errorMessage }}
+              </div>
+            }
           </div>
-          <div class="stats" *ngIf="run.status === 'completed'">
-            <span class="stat-badge added" *ngIf="run.snippetsAdded">+{{ run.snippetsAdded }}</span>
-            <span class="stat-badge updated" *ngIf="run.snippetsUpdated">~{{ run.snippetsUpdated }}</span>
-            <span class="stat-badge deleted" *ngIf="run.snippetsDeleted">-{{ run.snippetsDeleted }}</span>
-            <span class="stat-badge unchanged" *ngIf="run.snippetsUnchanged">={{ run.snippetsUnchanged }}</span>
-          </div>
-        </div>
-        <div *ngIf="run.errorMessage" style="color:var(--danger);font-size:0.8125rem;margin-top:0.25rem">
-          {{ run.errorMessage }}
-        </div>
+        }
       </div>
-    </div>
-    <div class="empty-state card" *ngIf="runs.length === 0 && gitCommits.length === 0 && !loading && !loadingCommits">
-      <p class="text-muted">No history yet</p>
-    </div>
-  `,
+    }
+    @if (runs.length === 0 && gitCommits.length === 0 && !loading && !loadingCommits) {
+      <div class="empty-state card">
+        <p class="text-muted">No history yet</p>
+      </div>
+    }
+    `,
   styles: [`
     .run-item { padding: 0.625rem 0; border-bottom: 1px solid var(--border); }
     .run-item:last-child { border-bottom: none; }

--- a/client/src/app/components/repositories/repository-list.component.ts
+++ b/client/src/app/components/repositories/repository-list.component.ts
@@ -13,132 +13,167 @@ import { RepositorySparklineComponent } from './repository-sparkline.component';
   standalone: true,
   imports: [CommonModule, RouterLink, FormsModule, RepositorySparklineComponent],
   template: `
-    <div class="warning-banner" *ngIf="!(healthService.isConnected$ | async)">
-      <i class="bi bi-exclamation-triangle"></i> Backend unavailable - some features are disabled
-    </div>
-
+    @if (!(healthService.isConnected$ | async)) {
+      <div class="warning-banner">
+        <i class="bi bi-exclamation-triangle"></i> Backend unavailable - some features are disabled
+      </div>
+    }
+    
     <div class="page-header">
       <h1>Repositories</h1>
       <a routerLink="/repositories/add" class="btn btn-primary" [class.disabled]="!(healthService.isConnected$ | async)">
         <i class="bi bi-plus-lg"></i> Add Repository
       </a>
     </div>
-
-    <div class="card" *ngIf="loading">
-      <div style="display:flex;justify-content:center;padding:2rem"><div class="spinner"></div></div>
-    </div>
-
-    <div class="empty-state card" *ngIf="!loading && repositories.length === 0">
-      <i class="bi bi-folder2-open"></i>
-      <h3>No repositories yet</h3>
-      <p>Add a repository to start indexing code.</p>
-      <a routerLink="/repositories/add" class="btn btn-primary">Add Repository</a>
-    </div>
-
-    <!-- Filters -->
-    <div class="card mb-2" *ngIf="!loading && repositories.length > 0" style="padding:0.75rem 1rem">
-      <div style="display:flex;gap:0.75rem;flex-wrap:wrap;align-items:center">
-        <input class="form-control" [(ngModel)]="nameFilter" placeholder="Search by name..." style="width:200px;padding:0.375rem 0.75rem">
-        <select class="form-control" [(ngModel)]="statusFilter" style="width:130px">
-          <option value="">All Status</option>
-          <option value="pending">Pending</option>
-          <option value="cloning">Cloning</option>
-          <option value="indexed">Indexed</option>
-          <option value="indexing">Indexing</option>
-          <option value="error">Error</option>
-        </select>
-        <select class="form-control" [(ngModel)]="orgFilter" style="width:160px">
-          <option value="">All Organizations</option>
-          <option *ngFor="let org of organizations" [value]="org.name">{{ org.name }} ({{ org.count }})</option>
-        </select>
-        <select class="form-control" [(ngModel)]="providerFilter" style="width:140px">
-          <option value="">All Providers</option>
-          <option value="GitHub">GitHub</option>
-          <option value="GitLab">GitLab</option>
-          <option value="Gitea">Gitea</option>
-          <option value="AzureDevOps">Azure DevOps</option>
-        </select>
-        <select class="form-control" [(ngModel)]="sortBy" style="width:150px">
-          <option value="name">Sort: Name</option>
-          <option value="lastSynced">Sort: Last Synced</option>
-          <option value="enrichments">Sort: Enrichments</option>
-          <option value="embeddings">Sort: Embeddings</option>
-        </select>
-        <button class="btn btn-sm btn-secondary" (click)="clearFilters()" *ngIf="nameFilter || statusFilter || providerFilter || orgFilter">
-          Clear
-        </button>
-        <span class="text-muted" style="margin-left:auto;font-size:0.8125rem">
-          Showing {{ filteredRepositories.length }} of {{ repositories.length }}
-        </span>
+    
+    @if (loading) {
+      <div class="card">
+        <div style="display:flex;justify-content:center;padding:2rem"><div class="spinner"></div></div>
       </div>
-    </div>
-
-    <div class="card" *ngIf="!loading && filteredRepositories.length > 0">
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Provider</th>
-            <th>Status</th>
-            <th>Activity</th>
-            <th>Enrichments</th>
-            <th>Embeddings</th>
-            <th>Last Synced</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr *ngFor="let repo of filteredRepositories">
-            <td>
-              <a [routerLink]="['/repositories', repo.id]">{{ repo.name }}</a>
-              <i *ngIf="repo.stats?.needsAttention" class="bi bi-exclamation-triangle-fill"
-                 style="color:#e6a700;margin-left:0.5rem;font-size:0.75rem;cursor:help"
-                 [title]="repo.stats?.attentionReason || 'Needs attention'"></i>
-              <div *ngIf="repo.organization" class="text-muted" style="font-size:0.75rem">{{ repo.organization }}</div>
-            </td>
-            <td><span class="badge badge-muted">{{ repo.provider }}</span></td>
-            <td>
-              <span class="badge" [ngClass]="statusClass(repo.status)">{{ repo.status }}</span>
-            </td>
-            <td>
-              <app-repository-sparkline
-                *ngIf="sparklines.get(repo.id)"
-                [weeklyData]="sparklines.get(repo.id)!.weeklyData">
-              </app-repository-sparkline>
-              <span *ngIf="!sparklines.get(repo.id)" class="text-muted" style="font-size:0.75rem">--</span>
-            </td>
-            <td class="text-muted">{{ repo.stats?.enrichmentCount || 0 }}</td>
-            <td>
-              <span *ngIf="repo.stats?.hasEmbeddings">{{ repo.stats?.embeddingCount }}</span>
-              <span class="text-muted" *ngIf="!repo.stats?.hasEmbeddings">--</span>
-            </td>
-            <td class="text-muted">{{ repo.lastSyncedAt ? (repo.lastSyncedAt | date:'short') : 'Never' }}</td>
-            <td>
-              <div style="display:flex;gap:0.375rem;align-items:center">
-                <button class="btn btn-sm btn-secondary" (click)="togglePin(repo.id)"
-                        [title]="pinService.isPinned(repo.id) ? 'Unpin from dashboard' : 'Pin to dashboard'">
-                  <i class="bi" [ngClass]="pinService.isPinned(repo.id) ? 'bi-pin-fill' : 'bi-pin-angle'"></i>
-                </button>
-                <button class="btn btn-sm btn-secondary" (click)="sync(repo)" [disabled]="isBusy(repo.id)">
-                  <span *ngIf="!isBusy(repo.id)"><i class="bi bi-arrow-repeat"></i> Sync</span>
-                  <span *ngIf="isBusy(repo.id)"><div class="spinner" style="width:14px;height:14px;display:inline-block;vertical-align:middle"></div> Syncing...</span>
-                </button>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-
-    <div *ngIf="!loading && repositories.length > 0 && filteredRepositories.length === 0" class="empty-state card">
-      <i class="bi bi-funnel"></i>
-      <h3>No matching repositories</h3>
-      <p>Try adjusting your filters.</p>
-      <button class="btn btn-secondary" (click)="clearFilters()">Clear Filters</button>
-    </div>
-
-    <div class="error-message" *ngIf="error">{{ error }}</div>
-  `,
+    }
+    
+    @if (!loading && repositories.length === 0) {
+      <div class="empty-state card">
+        <i class="bi bi-folder2-open"></i>
+        <h3>No repositories yet</h3>
+        <p>Add a repository to start indexing code.</p>
+        <a routerLink="/repositories/add" class="btn btn-primary">Add Repository</a>
+      </div>
+    }
+    
+    <!-- Filters -->
+    @if (!loading && repositories.length > 0) {
+      <div class="card mb-2" style="padding:0.75rem 1rem">
+        <div style="display:flex;gap:0.75rem;flex-wrap:wrap;align-items:center">
+          <input class="form-control" [(ngModel)]="nameFilter" placeholder="Search by name..." style="width:200px;padding:0.375rem 0.75rem">
+          <select class="form-control" [(ngModel)]="statusFilter" style="width:130px">
+            <option value="">All Status</option>
+            <option value="pending">Pending</option>
+            <option value="cloning">Cloning</option>
+            <option value="indexed">Indexed</option>
+            <option value="indexing">Indexing</option>
+            <option value="error">Error</option>
+          </select>
+          <select class="form-control" [(ngModel)]="orgFilter" style="width:160px">
+            <option value="">All Organizations</option>
+            @for (org of organizations; track org) {
+              <option [value]="org.name">{{ org.name }} ({{ org.count }})</option>
+            }
+          </select>
+          <select class="form-control" [(ngModel)]="providerFilter" style="width:140px">
+            <option value="">All Providers</option>
+            <option value="GitHub">GitHub</option>
+            <option value="GitLab">GitLab</option>
+            <option value="Gitea">Gitea</option>
+            <option value="AzureDevOps">Azure DevOps</option>
+          </select>
+          <select class="form-control" [(ngModel)]="sortBy" style="width:150px">
+            <option value="name">Sort: Name</option>
+            <option value="lastSynced">Sort: Last Synced</option>
+            <option value="enrichments">Sort: Enrichments</option>
+            <option value="embeddings">Sort: Embeddings</option>
+          </select>
+          @if (nameFilter || statusFilter || providerFilter || orgFilter) {
+            <button class="btn btn-sm btn-secondary" (click)="clearFilters()">
+              Clear
+            </button>
+          }
+          <span class="text-muted" style="margin-left:auto;font-size:0.8125rem">
+            Showing {{ filteredRepositories.length }} of {{ repositories.length }}
+          </span>
+        </div>
+      </div>
+    }
+    
+    @if (!loading && filteredRepositories.length > 0) {
+      <div class="card">
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Provider</th>
+              <th>Status</th>
+              <th>Activity</th>
+              <th>Enrichments</th>
+              <th>Embeddings</th>
+              <th>Last Synced</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (repo of filteredRepositories; track repo) {
+              <tr>
+                <td>
+                  <a [routerLink]="['/repositories', repo.id]">{{ repo.name }}</a>
+                  @if (repo.stats?.needsAttention) {
+                    <i class="bi bi-exclamation-triangle-fill"
+                      style="color:#e6a700;margin-left:0.5rem;font-size:0.75rem;cursor:help"
+                    [title]="repo.stats?.attentionReason || 'Needs attention'"></i>
+                  }
+                  @if (repo.organization) {
+                    <div class="text-muted" style="font-size:0.75rem">{{ repo.organization }}</div>
+                  }
+                </td>
+                <td><span class="badge badge-muted">{{ repo.provider }}</span></td>
+                <td>
+                  <span class="badge" [ngClass]="statusClass(repo.status)">{{ repo.status }}</span>
+                </td>
+                <td>
+                  @if (sparklines.get(repo.id)) {
+                    <app-repository-sparkline
+                      [weeklyData]="sparklines.get(repo.id)!.weeklyData">
+                    </app-repository-sparkline>
+                  }
+                  @if (!sparklines.get(repo.id)) {
+                    <span class="text-muted" style="font-size:0.75rem">--</span>
+                  }
+                </td>
+                <td class="text-muted">{{ repo.stats?.enrichmentCount || 0 }}</td>
+                <td>
+                  @if (repo.stats?.hasEmbeddings) {
+                    <span>{{ repo.stats?.embeddingCount }}</span>
+                  }
+                  @if (!repo.stats?.hasEmbeddings) {
+                    <span class="text-muted">--</span>
+                  }
+                </td>
+                <td class="text-muted">{{ repo.lastSyncedAt ? (repo.lastSyncedAt | date:'short') : 'Never' }}</td>
+                <td>
+                  <div style="display:flex;gap:0.375rem;align-items:center">
+                    <button class="btn btn-sm btn-secondary" (click)="togglePin(repo.id)"
+                      [title]="pinService.isPinned(repo.id) ? 'Unpin from dashboard' : 'Pin to dashboard'">
+                      <i class="bi" [ngClass]="pinService.isPinned(repo.id) ? 'bi-pin-fill' : 'bi-pin-angle'"></i>
+                    </button>
+                    <button class="btn btn-sm btn-secondary" (click)="sync(repo)" [disabled]="isBusy(repo.id)">
+                      @if (!isBusy(repo.id)) {
+                        <span><i class="bi bi-arrow-repeat"></i> Sync</span>
+                      }
+                      @if (isBusy(repo.id)) {
+                        <span><div class="spinner" style="width:14px;height:14px;display:inline-block;vertical-align:middle"></div> Syncing...</span>
+                      }
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+    
+    @if (!loading && repositories.length > 0 && filteredRepositories.length === 0) {
+      <div class="empty-state card">
+        <i class="bi bi-funnel"></i>
+        <h3>No matching repositories</h3>
+        <p>Try adjusting your filters.</p>
+        <button class="btn btn-secondary" (click)="clearFilters()">Clear Filters</button>
+      </div>
+    }
+    
+    @if (error) {
+      <div class="error-message">{{ error }}</div>
+    }
+    `,
   styles: [`
     .error-message { color: var(--danger); margin-top: 1rem; padding: 0.75rem; background: rgba(220,53,69,0.1); border-radius: var(--radius); }
     .warning-banner { background: rgba(255,193,7,0.15); color: #856404; border: 1px solid rgba(255,193,7,0.3); border-radius: var(--radius); padding: 0.5rem 1rem; margin-bottom: 1rem; font-size: var(--font-sm); }

--- a/client/src/app/components/repositories/repository-sparkline.component.ts
+++ b/client/src/app/components/repositories/repository-sparkline.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { WeeklyActivity } from '../../models/repository.model';
 
 interface DayCell {
@@ -12,22 +12,28 @@ interface DayCell {
 @Component({
   selector: 'app-repository-sparkline',
   standalone: true,
-  imports: [CommonModule],
+  imports: [],
   template: `
-    <svg [attr.width]="svgWidth" [attr.height]="svgHeight" *ngIf="cells.length > 0"
-         style="display:block" role="img" aria-label="Activity grid">
-      <rect *ngFor="let cell of cells"
+    @if (cells.length > 0) {
+      <svg [attr.width]="svgWidth" [attr.height]="svgHeight"
+        style="display:block" role="img" aria-label="Activity grid">
+        @for (cell of cells; track cell) {
+          <rect
             [attr.x]="cell.col * (cellSize + gap)"
             [attr.y]="cell.row * (cellSize + gap)"
             [attr.width]="cellSize"
             [attr.height]="cellSize"
             [attr.fill]="getColor(cell.commitCount)"
             [attr.rx]="1">
-        <title>{{ formatDate(cell.date) }}: {{ cell.commitCount }} commits</title>
-      </rect>
-    </svg>
-    <span *ngIf="cells.length === 0" class="text-muted" style="font-size:0.75rem">--</span>
-  `,
+            <title>{{ formatDate(cell.date) }}: {{ cell.commitCount }} commits</title>
+          </rect>
+        }
+      </svg>
+    }
+    @if (cells.length === 0) {
+      <span class="text-muted" style="font-size:0.75rem">--</span>
+    }
+    `,
   styles: [`
     :host { display: inline-block; }
   `]

--- a/client/src/app/components/search/search.component.ts
+++ b/client/src/app/components/search/search.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { CommonModule } from '@angular/common';
+
 import { RouterLink } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
 import { ApiService } from '../../services/api.service';
@@ -15,17 +15,17 @@ interface FilterOptions {
 @Component({
   selector: 'app-search',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink],
+  imports: [FormsModule, RouterLink],
   template: `
     <div class="page-header">
       <h1>Search</h1>
     </div>
-
+    
     <div class="card mb-2">
       <div style="display:flex;gap:0.75rem;align-items:end;flex-wrap:wrap">
         <div class="form-group" style="flex:1;margin-bottom:0;min-width:250px">
           <input class="form-control" [(ngModel)]="query" placeholder="Search code..."
-                 (keyup.enter)="search(true)" style="font-size:1rem;padding:0.75rem 1rem">
+            (keyup.enter)="search(true)" style="font-size:1rem;padding:0.75rem 1rem">
         </div>
         <div class="form-group" style="margin-bottom:0">
           <select class="form-control" [(ngModel)]="mode" style="width:130px">
@@ -34,94 +34,126 @@ interface FilterOptions {
             <option value="keyword">Keyword</option>
           </select>
         </div>
-        <div class="form-group" style="margin-bottom:0" *ngIf="filters">
-          <select class="form-control" [(ngModel)]="selectedRepo" style="width:160px">
-            <option value="">All Repos</option>
-            <option *ngFor="let r of filters.repositories" [value]="r.id">{{ r.name }}</option>
-          </select>
-        </div>
-        <div class="form-group" style="margin-bottom:0" *ngIf="filters">
-          <select class="form-control" [(ngModel)]="selectedLang" style="width:140px">
-            <option value="">All Languages</option>
-            <option *ngFor="let l of filters.languages" [value]="l">{{ l }}</option>
-          </select>
-        </div>
+        @if (filters) {
+          <div class="form-group" style="margin-bottom:0">
+            <select class="form-control" [(ngModel)]="selectedRepo" style="width:160px">
+              <option value="">All Repos</option>
+              @for (r of filters.repositories; track r) {
+                <option [value]="r.id">{{ r.name }}</option>
+              }
+            </select>
+          </div>
+        }
+        @if (filters) {
+          <div class="form-group" style="margin-bottom:0">
+            <select class="form-control" [(ngModel)]="selectedLang" style="width:140px">
+              <option value="">All Languages</option>
+              @for (l of filters.languages; track l) {
+                <option [value]="l">{{ l }}</option>
+              }
+            </select>
+          </div>
+        }
         <button class="btn btn-primary" (click)="search(true)" [disabled]="searching || !query">
           <i class="bi bi-search"></i> Search
         </button>
       </div>
     </div>
-
-    <div *ngIf="searching" style="display:flex;justify-content:center;padding:2rem"><div class="spinner"></div></div>
-
-    <div *ngIf="results && !searching">
-      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:1rem">
-        <span class="text-muted" style="font-size:0.875rem">
-          {{ results.totalCount }} results in {{ results.durationMs }}ms ({{ results.searchMode }})
-        </span>
-        <div style="display:flex;gap:0.5rem;align-items:center" *ngIf="results.totalCount > pageSize">
-          <button class="btn btn-sm btn-secondary" (click)="prevPage()" [disabled]="offset === 0">Previous</button>
-          <span class="text-muted" style="font-size:0.8125rem">
-            {{ offset + 1 }}-{{ Math.min(offset + pageSize, results.totalCount) }} of {{ results.totalCount }}
+    
+    @if (searching) {
+      <div style="display:flex;justify-content:center;padding:2rem"><div class="spinner"></div></div>
+    }
+    
+    @if (results && !searching) {
+      <div>
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:1rem">
+          <span class="text-muted" style="font-size:0.875rem">
+            {{ results.totalCount }} results in {{ results.durationMs }}ms ({{ results.searchMode }})
           </span>
-          <button class="btn btn-sm btn-secondary" (click)="nextPage()" [disabled]="offset + pageSize >= results.totalCount">Next</button>
+          @if (results.totalCount > pageSize) {
+            <div style="display:flex;gap:0.5rem;align-items:center">
+              <button class="btn btn-sm btn-secondary" (click)="prevPage()" [disabled]="offset === 0">Previous</button>
+              <span class="text-muted" style="font-size:0.8125rem">
+                {{ offset + 1 }}-{{ Math.min(offset + pageSize, results.totalCount) }} of {{ results.totalCount }}
+              </span>
+              <button class="btn btn-sm btn-secondary" (click)="nextPage()" [disabled]="offset + pageSize >= results.totalCount">Next</button>
+            </div>
+          }
         </div>
-      </div>
-
-      <div class="card search-result" *ngFor="let item of results.results" style="margin-bottom:0.75rem">
-        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem">
-          <div style="display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap">
-            <a [routerLink]="['/repositories', item.repositoryId]" class="badge badge-primary" style="text-decoration:none" *ngIf="item.repositoryName">
-              {{ item.repositoryName }}
-            </a>
-            <code style="font-size:0.8125rem">{{ item.filePath }}</code>
-            <span class="badge badge-muted" *ngIf="item.language">{{ item.language }}</span>
+        @for (item of results.results; track item) {
+          <div class="card search-result" style="margin-bottom:0.75rem">
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem">
+              <div style="display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap">
+                @if (item.repositoryName) {
+                  <a [routerLink]="['/repositories', item.repositoryId]" class="badge badge-primary" style="text-decoration:none">
+                    {{ item.repositoryName }}
+                  </a>
+                }
+                <code style="font-size:0.8125rem">{{ item.filePath }}</code>
+                @if (item.language) {
+                  <span class="badge badge-muted">{{ item.language }}</span>
+                }
+              </div>
+              <span class="badge badge-info">{{ formatScore(item.score) }}</span>
+            </div>
+            <pre style="margin:0;max-height:200px;overflow:hidden"><code>{{ truncateContent(item.content) }}</code></pre>
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-top:0.5rem">
+              @if (item.startLine) {
+                <span class="text-muted" style="font-size:0.75rem">
+                  Lines {{ item.startLine }}-{{ item.endLine }}
+                </span>
+              }
+              <a [routerLink]="['/enrichments']" [queryParams]="{repositoryId: item.repositoryId}"
+                class="text-muted" style="font-size:0.75rem">
+                View enrichments
+              </a>
+            </div>
           </div>
-          <span class="badge badge-info">{{ formatScore(item.score) }}</span>
+        }
+        <!-- Pagination at bottom -->
+        @if (results.totalCount > pageSize) {
+          <div style="display:flex;justify-content:center;gap:0.75rem;margin-top:1.5rem">
+            <button class="btn btn-secondary" (click)="prevPage()" [disabled]="offset === 0">Previous</button>
+            <span class="text-muted" style="align-self:center;font-size:0.875rem">
+              Page {{ currentPage }} of {{ totalPages }}
+            </span>
+            <button class="btn btn-secondary" (click)="nextPage()" [disabled]="offset + pageSize >= results.totalCount">Next</button>
+          </div>
+        }
+      </div>
+    }
+    
+    @if (results && results.results.length === 0 && !searching) {
+      <div class="card" style="text-align:center;padding:2rem">
+        <i class="bi bi-search" style="font-size:2rem;color:var(--text-muted);display:block;margin-bottom:1rem"></i>
+        <h3 style="margin-bottom:0.5rem">No results for "{{ query }}"</h3>
+        <p class="text-muted" style="margin-bottom:1rem">
+          Searched using <strong>{{ mode }}</strong> mode
+          @if (getActiveFilterLabel()) {
+            <span> with filters: {{ getActiveFilterLabel() }}</span>
+          }
+        </p>
+        <div style="text-align:left;max-width:400px;margin:0 auto;font-size:0.875rem">
+          <p style="font-weight:600;margin-bottom:0.5rem">Suggestions:</p>
+          <ul style="padding-left:1.25rem;margin:0">
+            @if (mode !== 'keyword') {
+              <li>Try <a href="javascript:void(0)" (click)="switchMode('keyword')">keyword search</a> for exact matches</li>
+            }
+            @if (mode !== 'semantic') {
+              <li>Try <a href="javascript:void(0)" (click)="switchMode('semantic')">semantic search</a> for conceptual matches</li>
+            }
+            @if (selectedRepo || selectedLang) {
+              <li>
+                <a href="javascript:void(0)" (click)="clearFilters()">Remove filters</a> to search all repos and languages
+              </li>
+            }
+            <li>Use simpler or more general keywords</li>
+            <li>Check that repositories are indexed (status: "indexed")</li>
+          </ul>
         </div>
-        <pre style="margin:0;max-height:200px;overflow:hidden"><code>{{ truncateContent(item.content) }}</code></pre>
-        <div style="display:flex;justify-content:space-between;align-items:center;margin-top:0.5rem">
-          <span class="text-muted" style="font-size:0.75rem" *ngIf="item.startLine">
-            Lines {{ item.startLine }}-{{ item.endLine }}
-          </span>
-          <a [routerLink]="['/enrichments']" [queryParams]="{repositoryId: item.repositoryId}"
-             class="text-muted" style="font-size:0.75rem">
-            View enrichments
-          </a>
-        </div>
       </div>
-
-      <!-- Pagination at bottom -->
-      <div style="display:flex;justify-content:center;gap:0.75rem;margin-top:1.5rem" *ngIf="results.totalCount > pageSize">
-        <button class="btn btn-secondary" (click)="prevPage()" [disabled]="offset === 0">Previous</button>
-        <span class="text-muted" style="align-self:center;font-size:0.875rem">
-          Page {{ currentPage }} of {{ totalPages }}
-        </span>
-        <button class="btn btn-secondary" (click)="nextPage()" [disabled]="offset + pageSize >= results.totalCount">Next</button>
-      </div>
-    </div>
-
-    <div *ngIf="results && results.results.length === 0 && !searching" class="card" style="text-align:center;padding:2rem">
-      <i class="bi bi-search" style="font-size:2rem;color:var(--text-muted);display:block;margin-bottom:1rem"></i>
-      <h3 style="margin-bottom:0.5rem">No results for "{{ query }}"</h3>
-      <p class="text-muted" style="margin-bottom:1rem">
-        Searched using <strong>{{ mode }}</strong> mode
-        <span *ngIf="getActiveFilterLabel()"> with filters: {{ getActiveFilterLabel() }}</span>
-      </p>
-      <div style="text-align:left;max-width:400px;margin:0 auto;font-size:0.875rem">
-        <p style="font-weight:600;margin-bottom:0.5rem">Suggestions:</p>
-        <ul style="padding-left:1.25rem;margin:0">
-          <li *ngIf="mode !== 'keyword'">Try <a href="javascript:void(0)" (click)="switchMode('keyword')">keyword search</a> for exact matches</li>
-          <li *ngIf="mode !== 'semantic'">Try <a href="javascript:void(0)" (click)="switchMode('semantic')">semantic search</a> for conceptual matches</li>
-          <li *ngIf="selectedRepo || selectedLang">
-            <a href="javascript:void(0)" (click)="clearFilters()">Remove filters</a> to search all repos and languages
-          </li>
-          <li>Use simpler or more general keywords</li>
-          <li>Check that repositories are indexed (status: "indexed")</li>
-        </ul>
-      </div>
-    </div>
-  `,
+    }
+    `,
   styles: [`
     .search-result:hover { border-color: var(--primary-light); }
     pre { font-size: 0.8rem; }

--- a/client/src/app/components/settings/settings.component.ts
+++ b/client/src/app/components/settings/settings.component.ts
@@ -12,181 +12,233 @@ import { environment } from '../../../environments/environment';
     <div class="page-header">
       <h1>Settings</h1>
     </div>
-
-    <div *ngIf="settings" style="display:grid;grid-template-columns:1fr 1fr;gap:1.5rem">
-      <!-- Embedding Section -->
-      <div class="card">
-        <h3 style="font-size:1.125rem;margin-bottom:0.75rem">Embedding Provider</h3>
-        <p class="text-muted" style="font-size:0.8125rem;margin-bottom:1rem">
-          Generates <strong>vector representations</strong> of your code for <strong>semantic search</strong> --
-          finding code by meaning, not just keywords. Also used for re-embedding when code changes.
-          Without this key, only keyword search (BM25) is available.
-        </p>
-
-        <div *ngIf="settings.embedding.hasKey" style="display:flex;align-items:center;gap:0.75rem;padding:0.75rem;background:var(--background-alt);border-radius:var(--radius);margin-bottom:1rem">
-          <i class="bi bi-key-fill" style="color:var(--success);font-size:1.25rem"></i>
-          <div style="flex:1">
-            <div style="font-weight:500;font-size:0.875rem">
-              Key configured
-              <i *ngIf="health && health.embeddingKeyValid" class="bi bi-check-circle-fill" style="color:var(--success);margin-left:0.375rem" title="Key is valid"></i>
-              <i *ngIf="health && !health.embeddingKeyValid && health.embeddingError" class="bi bi-x-circle-fill" style="color:var(--danger);margin-left:0.375rem" [title]="health.embeddingError"></i>
+    
+    @if (settings) {
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:1.5rem">
+        <!-- Embedding Section -->
+        <div class="card">
+          <h3 style="font-size:1.125rem;margin-bottom:0.75rem">Embedding Provider</h3>
+          <p class="text-muted" style="font-size:0.8125rem;margin-bottom:1rem">
+            Generates <strong>vector representations</strong> of your code for <strong>semantic search</strong> --
+            finding code by meaning, not just keywords. Also used for re-embedding when code changes.
+            Without this key, only keyword search (BM25) is available.
+          </p>
+          @if (settings.embedding.hasKey) {
+            <div style="display:flex;align-items:center;gap:0.75rem;padding:0.75rem;background:var(--background-alt);border-radius:var(--radius);margin-bottom:1rem">
+              <i class="bi bi-key-fill" style="color:var(--success);font-size:1.25rem"></i>
+              <div style="flex:1">
+                <div style="font-weight:500;font-size:0.875rem">
+                  Key configured
+                  @if (health && health.embeddingKeyValid) {
+                    <i class="bi bi-check-circle-fill" style="color:var(--success);margin-left:0.375rem" title="Key is valid"></i>
+                  }
+                  @if (health && !health.embeddingKeyValid && health.embeddingError) {
+                    <i class="bi bi-x-circle-fill" style="color:var(--danger);margin-left:0.375rem" [title]="health.embeddingError"></i>
+                  }
+                </div>
+                <div class="text-muted" style="font-size:0.8125rem">
+                  <code>{{ settings.embedding.maskedKey }}</code>
+                  <span class="badge" [ngClass]="settings.embedding.source === 'user' ? 'badge-primary' : 'badge-muted'" style="margin-left:0.375rem">
+                    {{ settings.embedding.source }}
+                  </span>
+                </div>
+              </div>
+              @if (settings.embedding.source === 'user') {
+                <button class="btn btn-sm btn-secondary" (click)="deleteEmbeddingKey()">Remove</button>
+              }
             </div>
-            <div class="text-muted" style="font-size:0.8125rem">
-              <code>{{ settings.embedding.maskedKey }}</code>
-              <span class="badge" [ngClass]="settings.embedding.source === 'user' ? 'badge-primary' : 'badge-muted'" style="margin-left:0.375rem">
-                {{ settings.embedding.source }}
-              </span>
+          }
+          @if (!settings.embedding.hasKey) {
+            <div style="padding:0.625rem 0.75rem;background:rgba(255,193,7,0.08);border:1px solid rgba(255,193,7,0.2);border-radius:var(--radius);margin-bottom:1rem;font-size:0.8125rem;color:#856404">
+              <i class="bi bi-exclamation-triangle"></i> No embedding key configured. Semantic search unavailable.
+            </div>
+          }
+          <div class="form-group">
+            <label>Server URL</label>
+            <input class="form-control" type="text" [(ngModel)]="embeddingBaseUrl" placeholder="https://api.openai.com/v1" style="margin-bottom:0.375rem">
+            <div style="display:flex;gap:0.375rem;flex-wrap:wrap;margin-bottom:0.5rem">
+              <button class="btn btn-xs btn-outline" (click)="embeddingBaseUrl = 'https://api.openai.com/v1'">OpenAI</button>
+              <button class="btn btn-xs btn-outline" (click)="embeddingBaseUrl = 'http://localhost:11434/v1'">Ollama</button>
+              <button class="btn btn-xs btn-outline" (click)="embeddingBaseUrl = 'https://api.groq.com/openai/v1'">Groq</button>
             </div>
           </div>
-          <button class="btn btn-sm btn-secondary" (click)="deleteEmbeddingKey()" *ngIf="settings.embedding.source === 'user'">Remove</button>
-        </div>
-
-        <div *ngIf="!settings.embedding.hasKey" style="padding:0.625rem 0.75rem;background:rgba(255,193,7,0.08);border:1px solid rgba(255,193,7,0.2);border-radius:var(--radius);margin-bottom:1rem;font-size:0.8125rem;color:#856404">
-          <i class="bi bi-exclamation-triangle"></i> No embedding key configured. Semantic search unavailable.
-        </div>
-
-        <div class="form-group">
-          <label>Server URL</label>
-          <input class="form-control" type="text" [(ngModel)]="embeddingBaseUrl" placeholder="https://api.openai.com/v1" style="margin-bottom:0.375rem">
-          <div style="display:flex;gap:0.375rem;flex-wrap:wrap;margin-bottom:0.5rem">
-            <button class="btn btn-xs btn-outline" (click)="embeddingBaseUrl = 'https://api.openai.com/v1'">OpenAI</button>
-            <button class="btn btn-xs btn-outline" (click)="embeddingBaseUrl = 'http://localhost:11434/v1'">Ollama</button>
-            <button class="btn btn-xs btn-outline" (click)="embeddingBaseUrl = 'https://api.groq.com/openai/v1'">Groq</button>
-          </div>
-        </div>
-        <div class="form-group">
-          <label>API Key</label>
-          <div style="display:flex;gap:0.5rem">
-            <input class="form-control" type="password" [(ngModel)]="embeddingKey" placeholder="sk-..." (keydown.enter)="embeddingKey && saveEmbedding()" style="flex:1">
-            <button class="btn btn-sm btn-secondary" (click)="testConnection('embedding')" [disabled]="testingEmbed" title="Test embedding connection">
-              <span *ngIf="testingEmbed">...</span>
-              <span *ngIf="!testingEmbed">Test</span>
-            </button>
-          </div>
-          <div *ngIf="embedTestResult" style="margin-top:0.375rem;font-size:0.8125rem">
-            <span *ngIf="embedTestResult.success" style="color:var(--success)">
-              <i class="bi bi-check-circle-fill"></i> Connected ({{ embedTestResult.latencyMs }}ms)
-            </span>
-            <span *ngIf="!embedTestResult.success" style="color:var(--danger)">
-              <i class="bi bi-x-circle-fill"></i> {{ embedTestResult.error }}
-            </span>
-          </div>
-        </div>
-        <div class="form-group">
-          <label>Model</label>
-          <input class="form-control" [(ngModel)]="embeddingModel" name="embeddingModel" list="embedding-models" placeholder="e.g., text-embedding-3-small">
-          <datalist id="embedding-models">
-            <option value="text-embedding-3-small">
-            <option value="text-embedding-3-large">
-            <option value="text-embedding-ada-002">
-          </datalist>
-        </div>
-        <button class="btn btn-primary btn-sm" (click)="saveEmbedding()" [disabled]="savingEmbed || (!embeddingKey && !embeddingModel && !embeddingBaseUrl)">
-          {{ savingEmbed ? 'Saving...' : 'Save Embedding Settings' }}
-        </button>
-        <span *ngIf="embedMessage" style="margin-left:0.75rem;color:var(--success);font-size:0.8125rem">{{ embedMessage }}</span>
-      </div>
-
-      <!-- LLM / Chat Section -->
-      <div class="card">
-        <h3 style="font-size:1.125rem;margin-bottom:0.75rem">LLM / Chat Provider</h3>
-        <p class="text-muted" style="font-size:0.8125rem;margin-bottom:1rem">
-          Powers the <strong>Chat</strong> feature (ask questions about your codebase) and generates
-          <strong>enrichments</strong>: architecture docs, wiki pages, cookbook guides, database schema docs,
-          and code summaries. Uses the same key as embedding if no separate LLM key is set.
-        </p>
-
-        <div *ngIf="settings.llm.hasKey" style="display:flex;align-items:center;gap:0.75rem;padding:0.75rem;background:var(--background-alt);border-radius:var(--radius);margin-bottom:1rem">
-          <i class="bi bi-key-fill" style="color:var(--success);font-size:1.25rem"></i>
-          <div style="flex:1">
-            <div style="font-weight:500;font-size:0.875rem">
-              LLM key configured
-              <i *ngIf="health && health.llmKeyValid" class="bi bi-check-circle-fill" style="color:var(--success);margin-left:0.375rem" title="Key is valid"></i>
-              <i *ngIf="health && !health.llmKeyValid && health.llmError" class="bi bi-x-circle-fill" style="color:var(--danger);margin-left:0.375rem" [title]="health.llmError"></i>
+          <div class="form-group">
+            <label>API Key</label>
+            <div style="display:flex;gap:0.5rem">
+              <input class="form-control" type="password" [(ngModel)]="embeddingKey" placeholder="sk-..." (keydown.enter)="embeddingKey && saveEmbedding()" style="flex:1">
+              <button class="btn btn-sm btn-secondary" (click)="testConnection('embedding')" [disabled]="testingEmbed" title="Test embedding connection">
+                @if (testingEmbed) {
+                  <span>...</span>
+                }
+                @if (!testingEmbed) {
+                  <span>Test</span>
+                }
+              </button>
             </div>
-            <code class="text-muted" style="font-size:0.8125rem">{{ settings.llm.maskedKey }}</code>
+            @if (embedTestResult) {
+              <div style="margin-top:0.375rem;font-size:0.8125rem">
+                @if (embedTestResult.success) {
+                  <span style="color:var(--success)">
+                    <i class="bi bi-check-circle-fill"></i> Connected ({{ embedTestResult.latencyMs }}ms)
+                  </span>
+                }
+                @if (!embedTestResult.success) {
+                  <span style="color:var(--danger)">
+                    <i class="bi bi-x-circle-fill"></i> {{ embedTestResult.error }}
+                  </span>
+                }
+              </div>
+            }
           </div>
-          <button class="btn btn-sm btn-secondary" (click)="deleteLlmKey()">Remove</button>
-        </div>
-
-        <div *ngIf="!settings.llm.hasKey && settings.embedding.hasKey" style="padding:0.625rem 0.75rem;background:rgba(0,164,220,0.08);border:1px solid rgba(0,164,220,0.2);border-radius:var(--radius);margin-bottom:1rem;font-size:0.8125rem;color:var(--accent)">
-          <i class="bi bi-info-circle"></i> Using embedding key as fallback for chat and enrichments.
-        </div>
-
-        <div *ngIf="!settings.llm.hasKey && !settings.embedding.hasKey" style="padding:0.625rem 0.75rem;background:rgba(255,193,7,0.08);border:1px solid rgba(255,193,7,0.2);border-radius:var(--radius);margin-bottom:1rem;font-size:0.8125rem;color:#856404">
-          <i class="bi bi-exclamation-triangle"></i> No LLM key configured. Chat and enrichment generation unavailable.
-        </div>
-
-        <div class="form-group">
-          <label>Server URL</label>
-          <input class="form-control" type="text" [(ngModel)]="llmBaseUrl" placeholder="https://api.openai.com/v1" style="margin-bottom:0.375rem">
-          <div style="display:flex;gap:0.375rem;flex-wrap:wrap;margin-bottom:0.5rem">
-            <button class="btn btn-xs btn-outline" (click)="llmBaseUrl = 'https://api.openai.com/v1'">OpenAI</button>
-            <button class="btn btn-xs btn-outline" (click)="llmBaseUrl = 'http://localhost:11434/v1'">Ollama</button>
-            <button class="btn btn-xs btn-outline" (click)="llmBaseUrl = 'https://api.groq.com/openai/v1'">Groq</button>
-          </div>
-        </div>
-        <div class="form-group">
-          <label>LLM API Key (optional, separate from embedding)</label>
-          <div style="display:flex;gap:0.5rem">
-            <input class="form-control" type="password" [(ngModel)]="llmKey" placeholder="sk-... (leave empty to use embedding key)" (keydown.enter)="llmKey && saveLlm()" style="flex:1">
-            <button class="btn btn-sm btn-secondary" (click)="testConnection('llm')" [disabled]="testingLlm" title="Test LLM connection">
-              <span *ngIf="testingLlm">...</span>
-              <span *ngIf="!testingLlm">Test</span>
-            </button>
-          </div>
-          <div *ngIf="llmTestResult" style="margin-top:0.375rem;font-size:0.8125rem">
-            <span *ngIf="llmTestResult.success" style="color:var(--success)">
-              <i class="bi bi-check-circle-fill"></i> Connected ({{ llmTestResult.latencyMs }}ms)
-            </span>
-            <span *ngIf="!llmTestResult.success" style="color:var(--danger)">
-              <i class="bi bi-x-circle-fill"></i> {{ llmTestResult.error }}
-            </span>
-          </div>
-        </div>
-        <div class="form-group">
-          <label>LLM Model</label>
-          <input class="form-control" [(ngModel)]="llmModel" name="llmModel" list="llm-models" placeholder="e.g., gpt-4o-mini">
-          <datalist id="llm-models">
-            <option value="gpt-4o-mini">
-            <option value="gpt-4o">
-            <option value="gpt-4.1-mini">
-            <option value="gpt-4.1">
-            <option value="gpt-5">
-            <option value="o3-mini">
-            <option value="claude-sonnet-4-20250514">
-          </datalist>
-        </div>
-        <button class="btn btn-primary btn-sm" (click)="saveLlm()" [disabled]="savingLlm || (!llmKey && !llmModel && !llmBaseUrl)">
-          {{ savingLlm ? 'Saving...' : 'Save LLM Settings' }}
-        </button>
-        <span *ngIf="llmMessage" style="margin-left:0.75rem;color:var(--success);font-size:0.8125rem">{{ llmMessage }}</span>
-      </div>
-    </div>
-
-    <!-- Change History -->
-    <div class="card" style="margin-top:1.5rem" *ngIf="history.length > 0">
-      <h3 style="font-size:1rem;margin-bottom:1rem">Change History</h3>
-      <div class="history-item" *ngFor="let entry of history">
-        <div style="display:flex;justify-content:space-between;align-items:center">
-          <div>
-            <span class="badge" [ngClass]="entry.action === 'removed' ? 'badge-danger' : entry.action === 'set' ? 'badge-success' : 'badge-info'">
-              {{ entry.action }}
-            </span>
-            <strong style="margin-left:0.5rem">{{ entry.field }}</strong>
-          </div>
-          <span class="text-muted" style="font-size:0.75rem">
-            <span *ngIf="entry.userEmail" style="margin-right:0.5rem">{{ entry.userEmail }}</span>{{ entry.createdAt | date:'short' }}
-          </span>
-        </div>
-        <div class="text-muted" style="font-size:0.8125rem;margin-top:0.25rem" *ngIf="entry.oldValue || entry.newValue">
-          <span *ngIf="entry.oldValue"><code>{{ entry.oldValue }}</code> &rarr; </span>
-          <code *ngIf="entry.newValue">{{ entry.newValue }}</code>
-          <span *ngIf="!entry.newValue && entry.action === 'removed'">(removed)</span>
-        </div>
-      </div>
-    </div>
-  `,
+          <div class="form-group">
+            <label>Model</label>
+            <input class="form-control" [(ngModel)]="embeddingModel" name="embeddingModel" list="embedding-models" placeholder="e.g., text-embedding-3-small">
+            <datalist id="embedding-models">
+              <option value="text-embedding-3-small">
+                <option value="text-embedding-3-large">
+                  <option value="text-embedding-ada-002">
+                  </datalist>
+                </div>
+                <button class="btn btn-primary btn-sm" (click)="saveEmbedding()" [disabled]="savingEmbed || (!embeddingKey && !embeddingModel && !embeddingBaseUrl)">
+                  {{ savingEmbed ? 'Saving...' : 'Save Embedding Settings' }}
+                </button>
+                @if (embedMessage) {
+                  <span style="margin-left:0.75rem;color:var(--success);font-size:0.8125rem">{{ embedMessage }}</span>
+                }
+              </div>
+              <!-- LLM / Chat Section -->
+              <div class="card">
+                <h3 style="font-size:1.125rem;margin-bottom:0.75rem">LLM / Chat Provider</h3>
+                <p class="text-muted" style="font-size:0.8125rem;margin-bottom:1rem">
+                  Powers the <strong>Chat</strong> feature (ask questions about your codebase) and generates
+                  <strong>enrichments</strong>: architecture docs, wiki pages, cookbook guides, database schema docs,
+                  and code summaries. Uses the same key as embedding if no separate LLM key is set.
+                </p>
+                @if (settings.llm.hasKey) {
+                  <div style="display:flex;align-items:center;gap:0.75rem;padding:0.75rem;background:var(--background-alt);border-radius:var(--radius);margin-bottom:1rem">
+                    <i class="bi bi-key-fill" style="color:var(--success);font-size:1.25rem"></i>
+                    <div style="flex:1">
+                      <div style="font-weight:500;font-size:0.875rem">
+                        LLM key configured
+                        @if (health && health.llmKeyValid) {
+                          <i class="bi bi-check-circle-fill" style="color:var(--success);margin-left:0.375rem" title="Key is valid"></i>
+                        }
+                        @if (health && !health.llmKeyValid && health.llmError) {
+                          <i class="bi bi-x-circle-fill" style="color:var(--danger);margin-left:0.375rem" [title]="health.llmError"></i>
+                        }
+                      </div>
+                      <code class="text-muted" style="font-size:0.8125rem">{{ settings.llm.maskedKey }}</code>
+                    </div>
+                    <button class="btn btn-sm btn-secondary" (click)="deleteLlmKey()">Remove</button>
+                  </div>
+                }
+                @if (!settings.llm.hasKey && settings.embedding.hasKey) {
+                  <div style="padding:0.625rem 0.75rem;background:rgba(0,164,220,0.08);border:1px solid rgba(0,164,220,0.2);border-radius:var(--radius);margin-bottom:1rem;font-size:0.8125rem;color:var(--accent)">
+                    <i class="bi bi-info-circle"></i> Using embedding key as fallback for chat and enrichments.
+                  </div>
+                }
+                @if (!settings.llm.hasKey && !settings.embedding.hasKey) {
+                  <div style="padding:0.625rem 0.75rem;background:rgba(255,193,7,0.08);border:1px solid rgba(255,193,7,0.2);border-radius:var(--radius);margin-bottom:1rem;font-size:0.8125rem;color:#856404">
+                    <i class="bi bi-exclamation-triangle"></i> No LLM key configured. Chat and enrichment generation unavailable.
+                  </div>
+                }
+                <div class="form-group">
+                  <label>Server URL</label>
+                  <input class="form-control" type="text" [(ngModel)]="llmBaseUrl" placeholder="https://api.openai.com/v1" style="margin-bottom:0.375rem">
+                  <div style="display:flex;gap:0.375rem;flex-wrap:wrap;margin-bottom:0.5rem">
+                    <button class="btn btn-xs btn-outline" (click)="llmBaseUrl = 'https://api.openai.com/v1'">OpenAI</button>
+                    <button class="btn btn-xs btn-outline" (click)="llmBaseUrl = 'http://localhost:11434/v1'">Ollama</button>
+                    <button class="btn btn-xs btn-outline" (click)="llmBaseUrl = 'https://api.groq.com/openai/v1'">Groq</button>
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label>LLM API Key (optional, separate from embedding)</label>
+                  <div style="display:flex;gap:0.5rem">
+                    <input class="form-control" type="password" [(ngModel)]="llmKey" placeholder="sk-... (leave empty to use embedding key)" (keydown.enter)="llmKey && saveLlm()" style="flex:1">
+                    <button class="btn btn-sm btn-secondary" (click)="testConnection('llm')" [disabled]="testingLlm" title="Test LLM connection">
+                      @if (testingLlm) {
+                        <span>...</span>
+                      }
+                      @if (!testingLlm) {
+                        <span>Test</span>
+                      }
+                    </button>
+                  </div>
+                  @if (llmTestResult) {
+                    <div style="margin-top:0.375rem;font-size:0.8125rem">
+                      @if (llmTestResult.success) {
+                        <span style="color:var(--success)">
+                          <i class="bi bi-check-circle-fill"></i> Connected ({{ llmTestResult.latencyMs }}ms)
+                        </span>
+                      }
+                      @if (!llmTestResult.success) {
+                        <span style="color:var(--danger)">
+                          <i class="bi bi-x-circle-fill"></i> {{ llmTestResult.error }}
+                        </span>
+                      }
+                    </div>
+                  }
+                </div>
+                <div class="form-group">
+                  <label>LLM Model</label>
+                  <input class="form-control" [(ngModel)]="llmModel" name="llmModel" list="llm-models" placeholder="e.g., gpt-4o-mini">
+                  <datalist id="llm-models">
+                    <option value="gpt-4o-mini">
+                      <option value="gpt-4o">
+                        <option value="gpt-4.1-mini">
+                          <option value="gpt-4.1">
+                            <option value="gpt-5">
+                              <option value="o3-mini">
+                                <option value="claude-sonnet-4-20250514">
+                                </datalist>
+                              </div>
+                              <button class="btn btn-primary btn-sm" (click)="saveLlm()" [disabled]="savingLlm || (!llmKey && !llmModel && !llmBaseUrl)">
+                                {{ savingLlm ? 'Saving...' : 'Save LLM Settings' }}
+                              </button>
+                              @if (llmMessage) {
+                                <span style="margin-left:0.75rem;color:var(--success);font-size:0.8125rem">{{ llmMessage }}</span>
+                              }
+                            </div>
+                          </div>
+                        }
+    
+                        <!-- Change History -->
+                        @if (history.length > 0) {
+                          <div class="card" style="margin-top:1.5rem">
+                            <h3 style="font-size:1rem;margin-bottom:1rem">Change History</h3>
+                            @for (entry of history; track entry) {
+                              <div class="history-item">
+                                <div style="display:flex;justify-content:space-between;align-items:center">
+                                  <div>
+                                    <span class="badge" [ngClass]="entry.action === 'removed' ? 'badge-danger' : entry.action === 'set' ? 'badge-success' : 'badge-info'">
+                                      {{ entry.action }}
+                                    </span>
+                                    <strong style="margin-left:0.5rem">{{ entry.field }}</strong>
+                                  </div>
+                                  <span class="text-muted" style="font-size:0.75rem">
+                                    @if (entry.userEmail) {
+                                      <span style="margin-right:0.5rem">{{ entry.userEmail }}</span>
+                                      }{{ entry.createdAt | date:'short' }}
+                                    </span>
+                                  </div>
+                                  @if (entry.oldValue || entry.newValue) {
+                                    <div class="text-muted" style="font-size:0.8125rem;margin-top:0.25rem">
+                                      @if (entry.oldValue) {
+                                        <span><code>{{ entry.oldValue }}</code> &rarr; </span>
+                                      }
+                                      @if (entry.newValue) {
+                                        <code>{{ entry.newValue }}</code>
+                                      }
+                                      @if (!entry.newValue && entry.action === 'removed') {
+                                        <span>(removed)</span>
+                                      }
+                                    </div>
+                                  }
+                                </div>
+                              }
+                            </div>
+                          }
+    `,
   styles: [`
     .history-item { padding: 0.625rem 0; border-bottom: 1px solid var(--border); }
     .history-item:last-child { border-bottom: none; }

--- a/client/src/app/components/tasks/sync-status.component.ts
+++ b/client/src/app/components/tasks/sync-status.component.ts
@@ -16,34 +16,42 @@ interface SyncStatus {
   standalone: true,
   imports: [CommonModule],
   template: `
-    <div class="card mb-2" *ngIf="status">
-      <div style="display:flex;justify-content:space-between;align-items:center">
-        <div>
-          <strong>Periodic Sync</strong>
-          <span class="badge" [ngClass]="status.enabled ? 'badge-success' : 'badge-muted'" style="margin-left:0.5rem">
-            {{ status.enabled ? 'Enabled' : 'Disabled' }}
-          </span>
+    @if (status) {
+      <div class="card mb-2">
+        <div style="display:flex;justify-content:space-between;align-items:center">
+          <div>
+            <strong>Periodic Sync</strong>
+            <span class="badge" [ngClass]="status.enabled ? 'badge-success' : 'badge-muted'" style="margin-left:0.5rem">
+              {{ status.enabled ? 'Enabled' : 'Disabled' }}
+            </span>
+          </div>
+          <div class="text-muted" style="font-size:0.8125rem">
+            {{ status.repositoriesTracked }} repositories tracked
+          </div>
         </div>
-        <div class="text-muted" style="font-size:0.8125rem">
-          {{ status.repositoriesTracked }} repositories tracked
-        </div>
+        @if (status.enabled) {
+          <div style="display:flex;gap:2rem;margin-top:0.75rem;font-size:0.8125rem">
+            <div>
+              <span class="text-muted">Interval:</span>
+              {{ status.intervalSeconds / 60 | number:'1.0-0' }} min
+            </div>
+            @if (status.lastRunAt) {
+              <div>
+                <span class="text-muted">Last sync:</span>
+                {{ status.lastRunAt | date:'short' }}
+              </div>
+            }
+            @if (status.nextRunAt) {
+              <div>
+                <span class="text-muted">Next sync:</span>
+                {{ status.nextRunAt | date:'short' }}
+              </div>
+            }
+          </div>
+        }
       </div>
-      <div style="display:flex;gap:2rem;margin-top:0.75rem;font-size:0.8125rem" *ngIf="status.enabled">
-        <div>
-          <span class="text-muted">Interval:</span>
-          {{ status.intervalSeconds / 60 | number:'1.0-0' }} min
-        </div>
-        <div *ngIf="status.lastRunAt">
-          <span class="text-muted">Last sync:</span>
-          {{ status.lastRunAt | date:'short' }}
-        </div>
-        <div *ngIf="status.nextRunAt">
-          <span class="text-muted">Next sync:</span>
-          {{ status.nextRunAt | date:'short' }}
-        </div>
-      </div>
-    </div>
-  `
+    }
+    `
 })
 export class SyncStatusComponent implements OnInit {
   status: SyncStatus | null = null;

--- a/client/src/app/components/tasks/task-dashboard.component.ts
+++ b/client/src/app/components/tasks/task-dashboard.component.ts
@@ -14,70 +14,90 @@ import { environment } from '../../../environments/environment';
     <div class="page-header">
       <h1>Task Queue</h1>
     </div>
-
+    
     <app-sync-status />
-
-    <div *ngIf="loading" style="display:flex;justify-content:center;padding:2rem"><div class="spinner"></div></div>
-
-    <div *ngIf="!loading">
-      <div style="display:flex;gap:0.5rem;margin-bottom:1.5rem">
-        <button class="btn" [ngClass]="tab === 'active' ? 'btn-primary' : 'btn-secondary'" (click)="tab='active'">
-          Active ({{ activeTasks.length }})
-        </button>
-        <button class="btn" [ngClass]="tab === 'pending' ? 'btn-primary' : 'btn-secondary'" (click)="tab='pending'">
-          Pending ({{ pendingTasks.length }})
-        </button>
-        <button class="btn" [ngClass]="tab === 'completed' ? 'btn-primary' : 'btn-secondary'" (click)="tab='completed'">
-          Completed ({{ completedTasks.length }})
-        </button>
-        <button class="btn" [ngClass]="tab === 'failed' ? 'btn-primary' : 'btn-secondary'" (click)="tab='failed'">
-          Failed ({{ failedTasks.length }})
-        </button>
-      </div>
-
-      <div class="card" *ngFor="let task of currentTasks" style="margin-bottom:0.75rem">
-        <div style="display:flex;justify-content:space-between;align-items:center">
-          <div>
-            <span class="badge" [ngClass]="statusClass(task.status)">{{ task.status }}</span>
-            <strong style="margin-left:0.75rem">{{ operationLabel(task.operation) }}</strong>
-            <span class="text-muted" style="margin-left:0.5rem;font-size:0.8125rem" *ngIf="getRepoName(task.repositoryId)">
-              on {{ getRepoName(task.repositoryId) }}
-            </span>
-          </div>
-          <div style="display:flex;align-items:center;gap:0.75rem">
-            <span class="text-muted" style="font-size:0.8125rem">{{ task.createdAt | date:'short' }}</span>
-            <span *ngIf="task.startedAt && task.completedAt" class="text-muted" style="font-size:0.75rem">
-              {{ getDuration(task.startedAt, task.completedAt) }}
-            </span>
-            <button *ngIf="task.status === 'Pending'" class="btn btn-sm" style="font-size:0.75rem;padding:0.25rem 0.5rem;color:var(--danger);border:1px solid var(--danger);background:none" (click)="cancelTask(task.id)">
-              Cancel
-            </button>
-            <button *ngIf="task.status === 'Running'" class="btn btn-sm" style="font-size:0.75rem;padding:0.25rem 0.5rem;color:var(--danger);border:1px solid var(--danger);background:none" (click)="forceCancelTask(task.id)">
-              Force Cancel
-            </button>
-          </div>
+    
+    @if (loading) {
+      <div style="display:flex;justify-content:center;padding:2rem"><div class="spinner"></div></div>
+    }
+    
+    @if (!loading) {
+      <div>
+        <div style="display:flex;gap:0.5rem;margin-bottom:1.5rem">
+          <button class="btn" [ngClass]="tab === 'active' ? 'btn-primary' : 'btn-secondary'" (click)="tab='active'">
+            Active ({{ activeTasks.length }})
+          </button>
+          <button class="btn" [ngClass]="tab === 'pending' ? 'btn-primary' : 'btn-secondary'" (click)="tab='pending'">
+            Pending ({{ pendingTasks.length }})
+          </button>
+          <button class="btn" [ngClass]="tab === 'completed' ? 'btn-primary' : 'btn-secondary'" (click)="tab='completed'">
+            Completed ({{ completedTasks.length }})
+          </button>
+          <button class="btn" [ngClass]="tab === 'failed' ? 'btn-primary' : 'btn-secondary'" (click)="tab='failed'">
+            Failed ({{ failedTasks.length }})
+          </button>
         </div>
-        <div *ngIf="task.status === 'Running' && (task.progress > 0 || task.progressMessage)" style="margin-top:0.75rem">
-          <div class="progress"><div class="progress-bar" [style.width.%]="task.progress || 2"></div></div>
-          <div style="display:flex;justify-content:space-between;margin-top:0.25rem">
-            <span class="text-muted" style="font-size:0.75rem">{{ task.progressMessage || '' }}</span>
-            <span class="text-muted" style="font-size:0.75rem">{{ task.progress }}%</span>
+        @for (task of currentTasks; track task) {
+          <div class="card" style="margin-bottom:0.75rem">
+            <div style="display:flex;justify-content:space-between;align-items:center">
+              <div>
+                <span class="badge" [ngClass]="statusClass(task.status)">{{ task.status }}</span>
+                <strong style="margin-left:0.75rem">{{ operationLabel(task.operation) }}</strong>
+                @if (getRepoName(task.repositoryId)) {
+                  <span class="text-muted" style="margin-left:0.5rem;font-size:0.8125rem">
+                    on {{ getRepoName(task.repositoryId) }}
+                  </span>
+                }
+              </div>
+              <div style="display:flex;align-items:center;gap:0.75rem">
+                <span class="text-muted" style="font-size:0.8125rem">{{ task.createdAt | date:'short' }}</span>
+                @if (task.startedAt && task.completedAt) {
+                  <span class="text-muted" style="font-size:0.75rem">
+                    {{ getDuration(task.startedAt, task.completedAt) }}
+                  </span>
+                }
+                @if (task.status === 'Pending') {
+                  <button class="btn btn-sm" style="font-size:0.75rem;padding:0.25rem 0.5rem;color:var(--danger);border:1px solid var(--danger);background:none" (click)="cancelTask(task.id)">
+                    Cancel
+                  </button>
+                }
+                @if (task.status === 'Running') {
+                  <button class="btn btn-sm" style="font-size:0.75rem;padding:0.25rem 0.5rem;color:var(--danger);border:1px solid var(--danger);background:none" (click)="forceCancelTask(task.id)">
+                    Force Cancel
+                  </button>
+                }
+              </div>
+            </div>
+            @if (task.status === 'Running' && (task.progress > 0 || task.progressMessage)) {
+              <div style="margin-top:0.75rem">
+                <div class="progress"><div class="progress-bar" [style.width.%]="task.progress || 2"></div></div>
+                <div style="display:flex;justify-content:space-between;margin-top:0.25rem">
+                  <span class="text-muted" style="font-size:0.75rem">{{ task.progressMessage || '' }}</span>
+                  <span class="text-muted" style="font-size:0.75rem">{{ task.progress }}%</span>
+                </div>
+                @if (task.chainStepIndex != null && task.chainTotalSteps) {
+                  <div class="text-muted" style="font-size:0.75rem;margin-top:0.25rem">
+                    Step {{ task.chainStepIndex! + 1 }} of {{ task.chainTotalSteps }}
+                  </div>
+                }
+              </div>
+            }
+            @if (task.errorMessage) {
+              <div style="margin-top:0.5rem;color:var(--danger);font-size:0.8125rem">
+                {{ task.errorMessage }}
+              </div>
+            }
           </div>
-          <div *ngIf="task.chainStepIndex != null && task.chainTotalSteps" class="text-muted" style="font-size:0.75rem;margin-top:0.25rem">
-            Step {{ task.chainStepIndex! + 1 }} of {{ task.chainTotalSteps }}
+        }
+        @if (currentTasks.length === 0) {
+          <div class="empty-state card">
+            <i class="bi bi-check-circle"></i>
+            <h3>No {{ tab }} tasks</h3>
           </div>
-        </div>
-        <div *ngIf="task.errorMessage" style="margin-top:0.5rem;color:var(--danger);font-size:0.8125rem">
-          {{ task.errorMessage }}
-        </div>
+        }
       </div>
-
-      <div *ngIf="currentTasks.length === 0" class="empty-state card">
-        <i class="bi bi-check-circle"></i>
-        <h3>No {{ tab }} tasks</h3>
-      </div>
-    </div>
-  `
+    }
+    `
 })
 export class TaskDashboardComponent implements OnInit, OnDestroy {
   tasks: IndexingTask[] = [];


### PR DESCRIPTION
Part of **epic #246**. Runs the official Angular control-flow migration (`ng generate @angular/core:control-flow`) across all **19 templates**, replacing `*ngIf`/`*ngFor`/`*ngSwitch` with `@if`/`@for`/`@switch`. Mechanical, semantics-preserving, Angular-authored.

## ⚠️ Review note — needs a runtime check
- ✅ `ng build` (strict templates) passes; ✅ `npm run lint` clean (0 errors).
- ❌ **Not runtime-verified**: this environment has no headless Chrome, so the Karma suite couldn't run. Please run the app / `npm test` before merging — this is a large template diff and I couldn't exercise it.

## Scope
Covers the **control-flow portion** of #263. The signals / `input()`-`output()` / `inject()` migration and native-dialog replacement remain (and the spec coverage that would verify this is #262, which is Chrome-blocked here).

Refs #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)