### PR TITLE
Repair the frontend unit-test suite (story #262)

### DIFF
--- a/client/src/app/app.spec.ts
+++ b/client/src/app/app.spec.ts
@@ -1,4 +1,6 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { AppComponent } from './app';
 import { provideRouter } from '@angular/router';
 
@@ -6,7 +8,7 @@ describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
-      providers: [provideRouter([])]
+      providers: [provideRouter([]), provideHttpClient(), provideHttpClientTesting()]
     }).compileComponents();
   });
 
@@ -17,6 +19,9 @@ describe('AppComponent', () => {
 
   it('should render sidebar', () => {
     const fixture = TestBed.createComponent(AppComponent);
+    // The sidebar sits behind @if (showChrome); showChrome is only set true on
+    // navigation to a non-excluded route, so set it explicitly here.
+    fixture.componentInstance.showChrome = true;
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('app-sidebar')).toBeTruthy();

--- a/client/src/app/components/auth/callback.component.spec.ts
+++ b/client/src/app/components/auth/callback.component.spec.ts
@@ -1,4 +1,6 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { CallbackComponent } from './callback.component';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
@@ -23,7 +25,9 @@ describe('CallbackComponent', () => {
               queryParamMap: convertToParamMap({ code: 'test-code', state: 'test-state' })
             }
           }
-        }
+        },
+        provideHttpClient(),
+        provideHttpClientTesting()
       ]
     }).compileComponents();
   });

--- a/client/src/app/components/chat/chat.component.spec.ts
+++ b/client/src/app/components/chat/chat.component.spec.ts
@@ -29,7 +29,9 @@ describe('ChatComponent', () => {
       ]
     }));
     httpMock.match('/api/v1/chat/status').forEach(r => r.flush({ available: true }));
-    httpMock.match('/api/v1/chat/conversations').forEach(r => r.flush({
+    // The component requests conversations with a `?limit=50` query, so match by
+    // URL prefix rather than exact string.
+    httpMock.match(r => r.url.startsWith('/api/v1/chat/conversations')).forEach(r => r.flush({
       conversations: [
         { id: 'conv-1', title: 'Test conversation', updatedAt: new Date().toISOString(), messageCount: 2, isPinned: false, pinnedAt: null }
       ], total: 1

--- a/client/src/app/components/enrichments/enrichment-browser.component.spec.ts
+++ b/client/src/app/components/enrichments/enrichment-browser.component.spec.ts
@@ -9,9 +9,10 @@ describe('EnrichmentBrowserComponent', () => {
   let apiServiceSpy: jasmine.SpyObj<ApiService>;
 
   beforeEach(async () => {
-    apiServiceSpy = jasmine.createSpyObj('ApiService', ['getEnrichments', 'getEnrichmentCounts']);
+    apiServiceSpy = jasmine.createSpyObj('ApiService', ['getEnrichments', 'getEnrichmentCounts', 'getGlobalStorage']);
     apiServiceSpy.getEnrichments.and.returnValue(of({ results: [], totalCount: 0, offset: 0, limit: 20 }));
     apiServiceSpy.getEnrichmentCounts.and.returnValue(of({}));
+    apiServiceSpy.getGlobalStorage.and.returnValue(of({} as any));
 
     await TestBed.configureTestingModule({
       imports: [EnrichmentBrowserComponent],

--- a/client/src/app/components/layout/sidebar.component.spec.ts
+++ b/client/src/app/components/layout/sidebar.component.spec.ts
@@ -1,4 +1,6 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { SidebarComponent } from './sidebar.component';
 import { provideRouter } from '@angular/router';
 
@@ -6,7 +8,7 @@ describe('SidebarComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [SidebarComponent],
-      providers: [provideRouter([])]
+      providers: [provideRouter([]), provideHttpClient(), provideHttpClientTesting()]
     }).compileComponents();
   });
 

--- a/client/src/app/components/repositories/repository-add.component.spec.ts
+++ b/client/src/app/components/repositories/repository-add.component.spec.ts
@@ -1,4 +1,6 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { RepositoryAddComponent } from './repository-add.component';
 import { ApiService } from '../../services/api.service';
 import { Router } from '@angular/router';
@@ -16,7 +18,9 @@ describe('RepositoryAddComponent', () => {
       imports: [RepositoryAddComponent],
       providers: [
         { provide: ApiService, useValue: apiServiceSpy },
-        { provide: Router, useValue: routerSpy }
+        { provide: Router, useValue: routerSpy },
+        provideHttpClient(),
+        provideHttpClientTesting()
       ]
     }).compileComponents();
   });

--- a/client/src/app/components/repositories/repository-list.component.spec.ts
+++ b/client/src/app/components/repositories/repository-list.component.spec.ts
@@ -1,4 +1,6 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { RepositoryListComponent } from './repository-list.component';
 import { ApiService } from '../../services/api.service';
 import { HealthService } from '../../services/health.service';
@@ -10,9 +12,10 @@ describe('RepositoryListComponent', () => {
   let healthServiceStub: { isConnected$: BehaviorSubject<boolean>; ngOnDestroy: jasmine.Spy };
 
   beforeEach(async () => {
-    apiServiceSpy = jasmine.createSpyObj('ApiService', ['getRepositories', 'syncRepository', 'getPipelines']);
+    apiServiceSpy = jasmine.createSpyObj('ApiService', ['getRepositories', 'syncRepository', 'getPipelines', 'getOrganizations']);
     apiServiceSpy.getRepositories.and.returnValue(of([]));
     apiServiceSpy.getPipelines.and.returnValue(of([]));
+    apiServiceSpy.getOrganizations.and.returnValue(of([] as any));
 
     healthServiceStub = {
       isConnected$: new BehaviorSubject<boolean>(true),
@@ -24,7 +27,9 @@ describe('RepositoryListComponent', () => {
       providers: [
         { provide: ApiService, useValue: apiServiceSpy },
         { provide: HealthService, useValue: healthServiceStub },
-        provideRouter([])
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting()
       ]
     }).compileComponents();
   });

--- a/client/src/app/components/tasks/task-dashboard.component.spec.ts
+++ b/client/src/app/components/tasks/task-dashboard.component.spec.ts
@@ -9,8 +9,9 @@ describe('TaskDashboardComponent', () => {
   let apiServiceSpy: jasmine.SpyObj<ApiService>;
 
   beforeEach(async () => {
-    apiServiceSpy = jasmine.createSpyObj('ApiService', ['getTasks']);
+    apiServiceSpy = jasmine.createSpyObj('ApiService', ['getTasks', 'getRepositories']);
     apiServiceSpy.getTasks.and.returnValue(of([]));
+    apiServiceSpy.getRepositories.and.returnValue(of([]));
 
     await TestBed.configureTestingModule({
       imports: [TaskDashboardComponent],

--- a/client/src/app/guards/auth.guard.spec.ts
+++ b/client/src/app/guards/auth.guard.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 import { authGuard } from './auth.guard';
 import { AuthService } from '../services/auth.service';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
@@ -25,7 +25,13 @@ describe('authGuard', () => {
   });
 
   it('should allow access when auth service reports authenticated', async () => {
-    const result = await TestBed.runInInjectionContext(() => authGuard(mockRoute, mockState));
+    // The guard awaits authService.ensureInitialized(), which loads the discovery
+    // document over HTTP when auth is enabled; flush it so the guard completes.
+    const httpMock = TestBed.inject(HttpTestingController);
+    const resultPromise = TestBed.runInInjectionContext(() => authGuard(mockRoute, mockState));
+    httpMock.match(() => true).forEach(r =>
+      r.flush({ authorization_endpoint: 'https://auth.test/authorize', token_endpoint: 'https://auth.test/token' }));
+    const result = await resultPromise;
     // In test environment auth.authority is set, but no tokens stored,
     // so behavior depends on authEnabled. With authority set it should redirect.
     expect(typeof result).toBe('boolean');

--- a/client/src/app/services/auth.service.spec.ts
+++ b/client/src/app/services/auth.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 import { AuthService } from './auth.service';
 
 describe('AuthService', () => {
@@ -35,6 +35,12 @@ describe('AuthService', () => {
   });
 
   it('should have ensureInitialized method', async () => {
-    await expectAsync(service.ensureInitialized()).toBeResolved();
+    // When auth is enabled, ensureInitialized loads the discovery document over
+    // HTTP; flush any such request so the promise resolves.
+    const httpMock = TestBed.inject(HttpTestingController);
+    const promise = service.ensureInitialized();
+    httpMock.match(() => true).forEach(r =>
+      r.flush({ authorization_endpoint: 'https://auth.test/authorize', token_endpoint: 'https://auth.test/token' }));
+    await expectAsync(promise).toBeResolved();
   });
 });


### PR DESCRIPTION
Part of **epic #246**. The Karma suite had drifted badly — **32 of 87 specs failed**. I ran it headless (Chrome) and fixed every failure: **now 87/87 green**.

## Fixes
- **HttpClient providers**: specs whose component tree pulls in root-provided services (`app`, `sidebar`, `callback`, `repository-list`/`-add`) failed with `NG0201: No provider for _HttpClient` → added `provideHttpClient()` + `provideHttpClientTesting()`.
- **Stale spies**: updated `ApiService` spy method lists the components had outgrown — `getGlobalStorage` (enrichment-browser), `getOrganizations` (repository-list), `getRepositories` (task-dashboard).
- **Chat spec**: match the conversations request by URL prefix so the `?limit=50` query is flushed (was leaving an open request, failing `verify()`).
- **App spec**: the sidebar sits behind `@if (showChrome)` → set `showChrome` before asserting it renders.
- **auth.service / auth.guard specs**: flush the discovery-document request that `ensureInitialized()` awaits, so the promise resolves instead of timing out.

## Verification
Ran `ng test --watch=false --browsers=ChromeHeadless` (via a local Puppeteer Chromium — **not committed**): **TOTAL: 87 SUCCESS**. `npm run lint` clean. Spec-only changes.

## Still open under #262
Adding specs for the still-untested high-risk components (`repository-detail`, `settings`, etc.) and a coverage threshold. This PR makes the suite trustworthy first.

Refs #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)