### PR TITLE
Migrate component inputs to signal input() (story #263)

### DIFF
--- a/client/src/app/components/repositories/repository-analytics.component.ts
+++ b/client/src/app/components/repositories/repository-analytics.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, OnInit, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
@@ -210,7 +210,7 @@ interface HeatmapCell {
   `]
 })
 export class RepositoryAnalyticsComponent implements OnInit {
-  @Input() repositoryId!: string;
+  readonly repositoryId = input.required<string>();
   languages: any[] = [];
   fileTypes: any[] = [];
   topTerms: any[] = [];
@@ -245,7 +245,7 @@ export class RepositoryAnalyticsComponent implements OnInit {
   constructor(private http: HttpClient) {}
 
   ngOnInit() {
-    const base = `${environment.apiUrl}/repositories/${this.repositoryId}/analytics`;
+    const base = `${environment.apiUrl}/repositories/${this.repositoryId()}/analytics`;
     this.http.get<any[]>(`${base}/languages`).subscribe(d => this.languages = d);
     this.http.get<any[]>(`${base}/file-types`).subscribe(d => this.fileTypes = d);
     this.http.get<any[]>(`${base}/top-terms?limit=40`).subscribe(d => this.topTerms = d);
@@ -255,7 +255,7 @@ export class RepositoryAnalyticsComponent implements OnInit {
 
   private loadHeatmap() {
     this.heatmapLoading = true;
-    const url = `${environment.apiUrl}/repositories/${this.repositoryId}/analytics/activity-heatmap?weeksBack=52`;
+    const url = `${environment.apiUrl}/repositories/${this.repositoryId()}/analytics/activity-heatmap?weeksBack=52`;
     this.http.get<ActivityHeatmap>(url).subscribe({
       next: data => {
         this.heatmapStats = data.stats;

--- a/client/src/app/components/repositories/repository-history.component.ts
+++ b/client/src/app/components/repositories/repository-history.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, OnInit, OnChanges, SimpleChanges, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
@@ -145,7 +145,7 @@ interface GitLogCommit {
   `]
 })
 export class RepositoryHistoryComponent implements OnInit, OnChanges {
-  @Input() repositoryId!: string;
+  readonly repositoryId = input.required<string>();
   @Input() ref = '';
   runs: IndexingRun[] = [];
   gitCommits: GitLogCommit[] = [];
@@ -157,7 +157,7 @@ export class RepositoryHistoryComponent implements OnInit, OnChanges {
   constructor(private http: HttpClient) {}
 
   ngOnInit() {
-    this.http.get<IndexingRun[]>(`${environment.apiUrl}/repositories/${this.repositoryId}/history`)
+    this.http.get<IndexingRun[]>(`${environment.apiUrl}/repositories/${this.repositoryId()}/history`)
       .subscribe({
         next: runs => { this.runs = runs; this.loading = false; },
         error: () => this.loading = false
@@ -184,7 +184,7 @@ export class RepositoryHistoryComponent implements OnInit, OnChanges {
       params = params.set('before', this.nextCursor);
     }
 
-    this.http.get<any>(`${environment.apiUrl}/repositories/${this.repositoryId}/git/log`, { params })
+    this.http.get<any>(`${environment.apiUrl}/repositories/${this.repositoryId()}/git/log`, { params })
       .subscribe({
         next: res => {
           this.gitCommits = [...this.gitCommits, ...(res.commits || [])];

--- a/client/src/app/components/repositories/repository-sparkline.component.ts
+++ b/client/src/app/components/repositories/repository-sparkline.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges } from '@angular/core';
+import { Component, OnChanges, input } from '@angular/core';
 
 import { WeeklyActivity } from '../../models/repository.model';
 
@@ -39,7 +39,7 @@ interface DayCell {
   `]
 })
 export class RepositorySparklineComponent implements OnChanges {
-  @Input() weeklyData: WeeklyActivity[] = [];
+  readonly weeklyData = input<WeeklyActivity[]>([]);
 
   cells: DayCell[] = [];
   cellSize = 4;
@@ -62,7 +62,7 @@ export class RepositorySparklineComponent implements OnChanges {
 
   private buildGrid() {
     // Take the last numWeeks of weekly data and expand into daily cells
-    const weeks = this.weeklyData.slice(-this.numWeeks);
+    const weeks = this.weeklyData().slice(-this.numWeeks);
     if (weeks.length === 0) {
       this.cells = [];
       return;


### PR DESCRIPTION
Part of **epic #246**. Runs the official Angular **signal-input migration** (`ng generate @angular/core:signal-input-migration`) over the three components using `@Input`, converting them to the signal-based `input()` API (reads become `this.x()`).

- **3 of 4** inputs migrated. `repository-history`'s `ref` is reassigned inside the component, so it can't be a read-only signal input — the tool correctly left it as `@Input` (mixing is supported).
- The output migration found no `@Output` to convert.

## Verification (full, against the now-green suite)
- `ng build` ✅ · `npm run lint` ✅ (0 errors) · Karma **87/87** ✅ (headless).

Signal-based component state, `inject()`-based DI, and native-dialog (`alert`/`confirm`) replacement remain under #263.

Refs #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)