### PR TITLE
Migrate constructor DI to inject() (story #263)

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, inject } from '@angular/core';
 
 import { RouterOutlet, RouterLink, Router, NavigationEnd } from '@angular/router';
 import { SidebarComponent } from './components/layout/sidebar.component';
@@ -62,13 +62,15 @@ import { filter } from 'rxjs/operators';
   `]
 })
 export class AppComponent implements OnInit, OnDestroy {
+  private api = inject(ApiService);
+  private auth = inject(AuthService);
+  private router = inject(Router);
+
   llmWarning: string | null = null;
   embeddingWarning: string | null = null;
   showChrome = false;
   private healthTimer: any;
   private readonly chromeExcludedRoutes = ['/login', '/callback'];
-
-  constructor(private api: ApiService, private auth: AuthService, private router: Router) {}
 
   ngOnInit() {
     this.router.events.pipe(

--- a/client/src/app/components/auth/callback.component.ts
+++ b/client/src/app/components/auth/callback.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
@@ -27,13 +27,11 @@ import { AuthService } from '../../services/auth.service';
     `
 })
 export class CallbackComponent implements OnInit {
-  error = '';
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private auth = inject(AuthService);
 
-  constructor(
-    private route: ActivatedRoute,
-    private router: Router,
-    private auth: AuthService
-  ) {}
+  error = '';
 
   async ngOnInit() {
     const code = this.route.snapshot.queryParamMap.get('code');

--- a/client/src/app/components/auth/login.component.ts
+++ b/client/src/app/components/auth/login.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
 import { Router } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
@@ -62,13 +62,18 @@ import { AuthService } from '../../services/auth.service';
   `]
 })
 export class LoginComponent {
+  private auth = inject(AuthService);
+  private router = inject(Router);
+
   authEnabled: boolean;
   authenticated: boolean;
   userName: string | null;
   signingIn = false;
   error = '';
 
-  constructor(private auth: AuthService, private router: Router) {
+  constructor() {
+    const auth = this.auth;
+
     this.authEnabled = auth.authEnabled;
     this.authenticated = auth.isAuthenticated();
     this.userName = auth.getUserName();

--- a/client/src/app/components/chat/chat.component.ts
+++ b/client/src/app/components/chat/chat.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, ElementRef, AfterViewChecked, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef, AfterViewChecked, ViewEncapsulation, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
@@ -385,6 +385,8 @@ interface ConversationGroup {
   `]
 })
 export class ChatComponent implements OnInit, AfterViewChecked {
+  private http = inject(HttpClient);
+
   @ViewChild('messagesContainer') messagesContainer!: ElementRef;
 
   messages: ChatMessage[] = [];
@@ -428,8 +430,6 @@ export class ChatComponent implements OnInit, AfterViewChecked {
     'ops': ['operations', 'monitoring', 'alerting', 'logging'],
     'doc': ['documentation', 'readme', 'wiki', 'guide'],
   };
-
-  constructor(private http: HttpClient) {}
 
   ngOnInit() {
     this.http.get<Repository[]>(`${environment.apiUrl}/repositories`).subscribe({

--- a/client/src/app/components/dashboard/dashboard.component.ts
+++ b/client/src/app/components/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { forkJoin } from 'rxjs';
@@ -178,17 +178,15 @@ import { RepositorySparklineComponent } from '../repositories/repository-sparkli
   `]
 })
 export class DashboardComponent implements OnInit {
+  private api = inject(ApiService);
+  private pinService = inject(PinService);
+  healthService = inject(HealthService);
+
   pinnedRepos: Repository[] = [];
   sparklines: Map<string, SparklineData> = new Map();
   loading = true;
   error = '';
   syncing: Record<string, boolean> = {};
-
-  constructor(
-    private api: ApiService,
-    private pinService: PinService,
-    public healthService: HealthService
-  ) {}
 
   ngOnInit() {
     this.loadPinnedRepos();

--- a/client/src/app/components/discovery/discovery.component.ts
+++ b/client/src/app/components/discovery/discovery.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { HttpClient } from '@angular/common/http';
@@ -167,6 +167,8 @@ interface DiscoveredRepo {
   `]
 })
 export class DiscoveryComponent {
+  private http = inject(HttpClient);
+
   provider = 'github';
   org = '';
   project = '';
@@ -181,8 +183,6 @@ export class DiscoveryComponent {
   hideTracked = false;
   sortBy = 'name';
   languageFilter = '';
-
-  constructor(private http: HttpClient) {}
 
   get selectedCount(): number {
     return this.repos.filter(r => r.selected && !r.alreadyTracked).length;

--- a/client/src/app/components/docs/docs.component.ts
+++ b/client/src/app/components/docs/docs.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterLink, RouterLinkActive } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
@@ -314,6 +314,9 @@ interface DocPage {
   `]
 })
 export class DocsComponent implements OnInit, OnDestroy {
+  private route = inject(ActivatedRoute);
+  private http = inject(HttpClient);
+
   pages: DocPage[] = [
     { slug: 'getting-started', title: 'Getting Started', icon: 'bi-rocket-takeoff' },
     { slug: 'repositories', title: 'Repositories', icon: 'bi-folder2-open' },
@@ -332,11 +335,6 @@ export class DocsComponent implements OnInit, OnDestroy {
   loading = false;
   error = '';
   private routeSub!: Subscription;
-
-  constructor(
-    private route: ActivatedRoute,
-    private http: HttpClient
-  ) {}
 
   ngOnInit(): void {
     this.routeSub = this.route.paramMap.subscribe(params => {

--- a/client/src/app/components/enrichments/enrichment-browser.component.ts
+++ b/client/src/app/components/enrichments/enrichment-browser.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
@@ -162,6 +162,9 @@ import { environment } from '../../../environments/environment';
     `
 })
 export class EnrichmentBrowserComponent implements OnInit {
+  private api = inject(ApiService);
+  private http = inject(HttpClient);
+
   enrichments: Enrichment[] = [];
   totalCount = 0;
   loading = true;
@@ -281,8 +284,6 @@ export class EnrichmentBrowserComponent implements OnInit {
     }
     this.loadEnrichments();
   }
-
-  constructor(private api: ApiService, private http: HttpClient) {}
 
   ngOnInit() {
     this.http.get<any[]>(`${environment.apiUrl}/repositories`).subscribe({

--- a/client/src/app/components/layout/sidebar.component.ts
+++ b/client/src/app/components/layout/sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 
 import { environment } from '../../../environments/environment';
@@ -171,9 +171,9 @@ import { AuthService } from '../../services/auth.service';
   `]
 })
 export class SidebarComponent {
-  isDevMode = !environment.production;
+  authService = inject(AuthService);
 
-  constructor(public authService: AuthService) {}
+  isDevMode = !environment.production;
 
   signOut() {
     this.authService.signOut();

--- a/client/src/app/components/repositories/repository-add.component.ts
+++ b/client/src/app/components/repositories/repository-add.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 
@@ -51,14 +51,15 @@ import { ApiService } from '../../services/api.service';
   `]
 })
 export class RepositoryAddComponent {
+  private api = inject(ApiService);
+  private router = inject(Router);
+
   url = '';
   pat = '';
   submitting = false;
   error = '';
   duplicateRepoId: string | null = null;
   private checkTimeout: any;
-
-  constructor(private api: ApiService, private router: Router) {}
 
   onUrlChange() {
     this.duplicateRepoId = null;

--- a/client/src/app/components/repositories/repository-analytics.component.ts
+++ b/client/src/app/components/repositories/repository-analytics.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, input } from '@angular/core';
+import { Component, OnInit, input, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
@@ -210,6 +210,8 @@ interface HeatmapCell {
   `]
 })
 export class RepositoryAnalyticsComponent implements OnInit {
+  private http = inject(HttpClient);
+
   readonly repositoryId = input.required<string>();
   languages: any[] = [];
   fileTypes: any[] = [];
@@ -241,8 +243,6 @@ export class RepositoryAnalyticsComponent implements OnInit {
   }
 
   private maxCommitsInDay = 1;
-
-  constructor(private http: HttpClient) {}
 
   ngOnInit() {
     const base = `${environment.apiUrl}/repositories/${this.repositoryId()}/analytics`;

--- a/client/src/app/components/repositories/repository-detail.component.ts
+++ b/client/src/app/components/repositories/repository-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, AfterViewChecked, ElementRef, NgZone, ViewEncapsulation, DestroyRef } from '@angular/core';
+import { Component, OnInit, OnDestroy, AfterViewChecked, ElementRef, NgZone, ViewEncapsulation, DestroyRef, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
@@ -1703,6 +1703,15 @@ interface CommitComparison {
   `]
 })
 export class RepositoryDetailComponent implements OnInit, OnDestroy, AfterViewChecked {
+  private api = inject(ApiService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private http = inject(HttpClient);
+  private sanitizer = inject(DomSanitizer);
+  private el = inject(ElementRef);
+  private zone = inject(NgZone);
+  private destroyRef = inject(DestroyRef);
+
   repo: Repository | null = null;
   loading = true;
   syncing = false;
@@ -1765,17 +1774,6 @@ export class RepositoryDetailComponent implements OnInit, OnDestroy, AfterViewCh
     'testanalysis': 'Testing', 'securityanalysis': 'Security', 'deploymentanalysis': 'Deployment',
     'operationsanalysis': 'Operations', 'localsetupguide': 'Local Setup', 'techstack': 'Tech Stack'
   };
-
-  constructor(
-    private api: ApiService,
-    private route: ActivatedRoute,
-    private router: Router,
-    private http: HttpClient,
-    private sanitizer: DomSanitizer,
-    private el: ElementRef,
-    private zone: NgZone,
-    private destroyRef: DestroyRef
-  ) {}
 
   ngOnDestroy() {
     // Stop insights polling and its timers so they don't keep firing (and making

--- a/client/src/app/components/repositories/repository-history.component.ts
+++ b/client/src/app/components/repositories/repository-history.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, OnChanges, SimpleChanges, input } from '@angular/core';
+import { Component, Input, OnInit, OnChanges, SimpleChanges, input, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
@@ -145,6 +145,8 @@ interface GitLogCommit {
   `]
 })
 export class RepositoryHistoryComponent implements OnInit, OnChanges {
+  private http = inject(HttpClient);
+
   readonly repositoryId = input.required<string>();
   @Input() ref = '';
   runs: IndexingRun[] = [];
@@ -153,8 +155,6 @@ export class RepositoryHistoryComponent implements OnInit, OnChanges {
   loadingCommits = false;
   hasMoreCommits = false;
   private nextCursor: string | null = null;
-
-  constructor(private http: HttpClient) {}
 
   ngOnInit() {
     this.http.get<IndexingRun[]>(`${environment.apiUrl}/repositories/${this.repositoryId()}/history`)

--- a/client/src/app/components/repositories/repository-list.component.ts
+++ b/client/src/app/components/repositories/repository-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -181,6 +181,10 @@ import { RepositorySparklineComponent } from './repository-sparkline.component';
   `]
 })
 export class RepositoryListComponent implements OnInit {
+  private api = inject(ApiService);
+  healthService = inject(HealthService);
+  pinService = inject(PinService);
+
   repositories: Repository[] = [];
   loading = true;
   error = '';
@@ -193,8 +197,6 @@ export class RepositoryListComponent implements OnInit {
   orgFilter = '';
   sortBy = 'name';
   organizations: { name: string; count: number }[] = [];
-
-  constructor(private api: ApiService, public healthService: HealthService, public pinService: PinService) {}
 
   ngOnInit() {
     this.loadRepositories();

--- a/client/src/app/components/search/search.component.ts
+++ b/client/src/app/components/search/search.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { RouterLink } from '@angular/router';
@@ -160,6 +160,9 @@ interface FilterOptions {
   `]
 })
 export class SearchComponent implements OnInit {
+  private api = inject(ApiService);
+  private http = inject(HttpClient);
+
   query = '';
   mode = 'hybrid';
   selectedRepo = '';
@@ -170,8 +173,6 @@ export class SearchComponent implements OnInit {
   offset = 0;
   pageSize = 10;
   Math = Math;
-
-  constructor(private api: ApiService, private http: HttpClient) {}
 
   ngOnInit() {
     this.http.get<FilterOptions>(`${environment.apiUrl}/search/filters`).subscribe({

--- a/client/src/app/components/settings/settings.component.ts
+++ b/client/src/app/components/settings/settings.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
@@ -248,6 +248,8 @@ import { environment } from '../../../environments/environment';
   `]
 })
 export class SettingsComponent implements OnInit {
+  private http = inject(HttpClient);
+
   embeddingKey = '';
   embeddingModel = '';
   embeddingBaseUrl = '';
@@ -265,8 +267,6 @@ export class SettingsComponent implements OnInit {
   embedTestResult: any = null;
   llmTestResult: any = null;
   health: any = null;
-
-  constructor(private http: HttpClient) {}
 
   ngOnInit() {
     this.embedMessage = '';

--- a/client/src/app/components/tasks/sync-status.component.ts
+++ b/client/src/app/components/tasks/sync-status.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
@@ -54,9 +54,9 @@ interface SyncStatus {
     `
 })
 export class SyncStatusComponent implements OnInit {
-  status: SyncStatus | null = null;
+  private http = inject(HttpClient);
 
-  constructor(private http: HttpClient) {}
+  status: SyncStatus | null = null;
 
   ngOnInit() {
     this.http.get<SyncStatus>(`${environment.apiUrl}/sync/status`).subscribe({

--- a/client/src/app/components/tasks/task-dashboard.component.ts
+++ b/client/src/app/components/tasks/task-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { ApiService } from '../../services/api.service';
@@ -100,6 +100,9 @@ import { environment } from '../../../environments/environment';
     `
 })
 export class TaskDashboardComponent implements OnInit, OnDestroy {
+  private api = inject(ApiService);
+  private http = inject(HttpClient);
+
   tasks: IndexingTask[] = [];
   repos: { id: string; name: string }[] = [];
   loading = true;
@@ -132,8 +135,6 @@ export class TaskDashboardComponent implements OnInit, OnDestroy {
   };
 
   private baseUrl = environment.apiUrl;
-
-  constructor(private api: ApiService, private http: HttpClient) {}
 
   ngOnInit() {
     this.loadTasks();

--- a/client/src/app/services/api.service.ts
+++ b/client/src/app/services/api.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Repository, CreateRepositoryRequest, SparklineData, ActivityHeatmap, StorageStats } from '../models/repository.model';
@@ -9,9 +9,9 @@ import { environment } from '../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class ApiService {
-  private baseUrl = environment.apiUrl;
+  private http = inject(HttpClient);
 
-  constructor(private http: HttpClient) {}
+  private baseUrl = environment.apiUrl;
 
   // Repositories
   getRepositories(): Observable<Repository[]> {

--- a/client/src/app/services/auth.service.ts
+++ b/client/src/app/services/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject, Observable, firstValueFrom } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
@@ -28,6 +28,9 @@ interface IdTokenClaims {
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
+  private http = inject(HttpClient);
+  private router = inject(Router);
+
   private isAuthenticatedSubject = new BehaviorSubject<boolean>(false);
   public isAuthenticated$: Observable<boolean> = this.isAuthenticatedSubject.asObservable();
 
@@ -46,7 +49,7 @@ export class AuthService {
     return !!environment.auth.authority;
   }
 
-  constructor(private http: HttpClient, private router: Router) {
+  constructor() {
     this.checkAuthState();
     if (this.authEnabled) {
       this.loadDiscoveryDocument();

--- a/client/src/app/services/health.service.ts
+++ b/client/src/app/services/health.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Subscription, timer, of } from 'rxjs';
 import { catchError, timeout, map, switchMap } from 'rxjs/operators';
@@ -6,6 +6,8 @@ import { environment } from '../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class HealthService implements OnDestroy {
+  private http = inject(HttpClient);
+
   private readonly POLL_INTERVAL = 30_000;
   private readonly TIMEOUT = 5_000;
   private readonly healthUrl = '/health';
@@ -13,7 +15,7 @@ export class HealthService implements OnDestroy {
   isConnected$ = new BehaviorSubject<boolean>(true);
   private pollSubscription?: Subscription;
 
-  constructor(private http: HttpClient) {
+  constructor() {
     this.startPolling();
   }
 


### PR DESCRIPTION
Part of **epic #246**. Runs the official Angular **inject() migration** (`ng generate @angular/core:inject-migration`) across all components and services, replacing constructor-parameter injection with the `inject()` function — aligning the whole client with the modern DI style already used by the functional interceptor/guard.

## Verification (full, against the green suite)
- `ng build` ✅ · `npm run lint` ✅ (0 errors) · Karma **87/87** ✅ (headless).

Signal-based component state and native-dialog (`alert`/`confirm`) replacement remain under #263.

Refs #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)