### PR TITLE
Add specs for sync-status, login, and sparkline (story #262)

### DIFF
--- a/client/src/app/components/auth/login.component.spec.ts
+++ b/client/src/app/components/auth/login.component.spec.ts
@@ -1,0 +1,66 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { LoginComponent } from './login.component';
+import { AuthService } from '../../services/auth.service';
+
+describe('LoginComponent', () => {
+  let authSpy: jasmine.SpyObj<AuthService>;
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  function setup(opts: { authEnabled?: boolean; authenticated?: boolean; userName?: string | null } = {})
+    : ComponentFixture<LoginComponent> {
+    authSpy = jasmine.createSpyObj<AuthService>(
+      'AuthService',
+      ['isAuthenticated', 'getUserName', 'signIn', 'signOut'],
+      { authEnabled: opts.authEnabled ?? true },
+    );
+    authSpy.isAuthenticated.and.returnValue(opts.authenticated ?? false);
+    authSpy.getUserName.and.returnValue(opts.userName ?? null);
+    authSpy.signIn.and.returnValue(Promise.resolve());
+
+    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
+    TestBed.configureTestingModule({
+      imports: [LoginComponent],
+      providers: [
+        { provide: AuthService, useValue: authSpy },
+        { provide: Router, useValue: routerSpy },
+      ],
+    });
+    return TestBed.createComponent(LoginComponent);
+  }
+
+  it('should reflect the auth state from the service', () => {
+    const fixture = setup({ authEnabled: true, authenticated: true, userName: 'Ada' });
+    const c = fixture.componentInstance;
+    expect(c.authEnabled).toBeTrue();
+    expect(c.authenticated).toBeTrue();
+    expect(c.userName).toBe('Ada');
+  });
+
+  it('should call auth.signIn() on signIn()', async () => {
+    const fixture = setup();
+    await fixture.componentInstance.signIn();
+    expect(authSpy.signIn).toHaveBeenCalled();
+  });
+
+  it('should surface an error and reset signingIn when signIn fails', async () => {
+    const fixture = setup();
+    authSpy.signIn.and.returnValue(Promise.reject(new Error('boom')));
+    await fixture.componentInstance.signIn();
+    expect(fixture.componentInstance.error).toBe('boom');
+    expect(fixture.componentInstance.signingIn).toBeFalse();
+  });
+
+  it('should navigate to /repositories from goToApp()', () => {
+    const fixture = setup();
+    fixture.componentInstance.goToApp();
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/repositories']);
+  });
+
+  it('should call auth.signOut() on signOut()', () => {
+    const fixture = setup();
+    fixture.componentInstance.signOut();
+    expect(authSpy.signOut).toHaveBeenCalled();
+  });
+});

--- a/client/src/app/components/repositories/repository-sparkline.component.spec.ts
+++ b/client/src/app/components/repositories/repository-sparkline.component.spec.ts
@@ -1,0 +1,42 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { RepositorySparklineComponent } from './repository-sparkline.component';
+
+describe('RepositorySparklineComponent', () => {
+  let fixture: ComponentFixture<RepositorySparklineComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RepositorySparklineComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(RepositorySparklineComponent);
+  });
+
+  it('should render a placeholder when there is no activity', () => {
+    fixture.componentRef.setInput('weeklyData', []);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('svg')).toBeNull();
+    expect(el.textContent).toContain('--');
+  });
+
+  it('should expand each week into 7 day-cells', () => {
+    fixture.componentRef.setInput('weeklyData', [
+      { weekStart: '2026-01-05', commitCount: 4 },
+      { weekStart: '2026-01-12', commitCount: 0 },
+    ]);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.cells.length).toBe(14);
+    expect((fixture.nativeElement as HTMLElement).querySelectorAll('rect').length).toBe(14);
+  });
+
+  it('should color cells by commit intensity', () => {
+    fixture.componentRef.setInput('weeklyData', [{ weekStart: '2026-01-05', commitCount: 10 }]);
+    fixture.detectChanges();
+
+    const c = fixture.componentInstance;
+    expect(c.getColor(0)).toBe('#ebedf0'); // no commits
+    expect(c.getColor(10)).toBe('#196127'); // max intensity
+  });
+});

--- a/client/src/app/components/tasks/sync-status.component.spec.ts
+++ b/client/src/app/components/tasks/sync-status.component.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { SyncStatusComponent } from './sync-status.component';
+import { environment } from '../../../environments/environment';
+
+describe('SyncStatusComponent', () => {
+  let httpMock: HttpTestingController;
+  const url = `${environment.apiUrl}/sync/status`;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SyncStatusComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(SyncStatusComponent);
+    fixture.detectChanges();
+    httpMock.expectOne(url).flush({ enabled: false, intervalSeconds: 0, repositoriesTracked: 0 });
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should render nothing before the status loads', () => {
+    const fixture = TestBed.createComponent(SyncStatusComponent);
+    // ngOnInit runs on first detectChanges; status is still null.
+    expect((fixture.nativeElement as HTMLElement).querySelector('.card')).toBeNull();
+    fixture.detectChanges();
+    httpMock.expectOne(url).flush({ enabled: false, intervalSeconds: 0, repositoriesTracked: 0 });
+  });
+
+  it('should load and render the sync status on init', () => {
+    const fixture = TestBed.createComponent(SyncStatusComponent);
+    fixture.detectChanges();
+    httpMock.expectOne(url).flush({
+      enabled: true,
+      intervalSeconds: 600,
+      repositoriesTracked: 3,
+    });
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('Periodic Sync');
+    expect(text).toContain('Enabled');
+    expect(text).toContain('3 repositories tracked');
+  });
+});


### PR DESCRIPTION
Part of **epic #246**. Behavioral specs for three previously-untested components, taking the suite from **87 → 98** passing.

- **SyncStatusComponent**: loads `/sync/status` on init and renders the status card; renders nothing before it loads.
- **LoginComponent**: reflects auth state, calls `signIn`/`signOut`, surfaces sign-in errors, navigates to `/repositories`.
- **RepositorySparklineComponent**: expands weekly activity into 7 day-cells per week, shows a placeholder when empty, colors cells by commit intensity.

## Verification
`npm run lint` ✅ (0 errors) · Karma **98/98** ✅ (headless).

Larger untested components (`repository-detail`, `settings`, `dashboard`, `discovery`, `docs`, `analytics`, `history`) and a coverage threshold remain under #262.

Refs #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)