### PR TITLE
Add specs for dashboard and repository-analytics (story #262)

### DIFF
--- a/client/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/client/src/app/components/dashboard/dashboard.component.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { of, BehaviorSubject } from 'rxjs';
+import { provideRouter } from '@angular/router';
+import { DashboardComponent } from './dashboard.component';
+import { ApiService } from '../../services/api.service';
+import { PinService } from '../../services/pin.service';
+import { HealthService } from '../../services/health.service';
+
+describe('DashboardComponent', () => {
+  let apiSpy: jasmine.SpyObj<ApiService>;
+  let pinSpy: jasmine.SpyObj<PinService>;
+
+  function setup(pinnedIds: string[]): ComponentFixture<DashboardComponent> {
+    apiSpy = jasmine.createSpyObj('ApiService', ['getRepository', 'getBulkSparklines', 'syncRepository']);
+    apiSpy.getBulkSparklines.and.returnValue(of({}));
+    apiSpy.syncRepository.and.returnValue(of({} as any));
+    pinSpy = jasmine.createSpyObj('PinService', ['getPinnedIds']);
+    pinSpy.getPinnedIds.and.returnValue(pinnedIds);
+
+    TestBed.configureTestingModule({
+      imports: [DashboardComponent],
+      providers: [
+        { provide: ApiService, useValue: apiSpy },
+        { provide: PinService, useValue: pinSpy },
+        { provide: HealthService, useValue: { isConnected$: new BehaviorSubject(true) } },
+        provideRouter([]),
+      ],
+    });
+    return TestBed.createComponent(DashboardComponent);
+  }
+
+  it('should not fetch repositories when nothing is pinned', () => {
+    const fixture = setup([]);
+    fixture.detectChanges();
+    expect(fixture.componentInstance.loading).toBeFalse();
+    expect(fixture.componentInstance.pinnedRepos.length).toBe(0);
+    expect(apiSpy.getRepository).not.toHaveBeenCalled();
+  });
+
+  it('should load pinned repositories and their sparklines', () => {
+    const fixture = setup(['r1', 'r2']);
+    apiSpy.getRepository.and.callFake((id: string) => of({ id } as any));
+    fixture.detectChanges();
+
+    expect(apiSpy.getRepository).toHaveBeenCalledTimes(2);
+    expect(fixture.componentInstance.pinnedRepos.map(r => r.id)).toEqual(['r1', 'r2']);
+    expect(apiSpy.getBulkSparklines).toHaveBeenCalled();
+    expect(fixture.componentInstance.loading).toBeFalse();
+  });
+
+  it('should sync a repository through the api', () => {
+    const fixture = setup([]);
+    fixture.detectChanges();
+    fixture.componentInstance.sync({ id: 'r1' } as any);
+    expect(apiSpy.syncRepository).toHaveBeenCalledWith('r1');
+  });
+});

--- a/client/src/app/components/repositories/repository-analytics.component.spec.ts
+++ b/client/src/app/components/repositories/repository-analytics.component.spec.ts
@@ -1,0 +1,59 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { RepositoryAnalyticsComponent } from './repository-analytics.component';
+
+describe('RepositoryAnalyticsComponent', () => {
+  let httpMock: HttpTestingController;
+  let fixture: ComponentFixture<RepositoryAnalyticsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RepositoryAnalyticsComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture = TestBed.createComponent(RepositoryAnalyticsComponent);
+    fixture.componentRef.setInput('repositoryId', 'repo-1');
+  });
+
+  afterEach(() => httpMock.verify());
+
+  // Some analytics URLs embed a query string (e.g. top-terms?limit=40), which
+  // lands in HttpRequest.url, so match by substring rather than suffix.
+  function flushEndingWith(suffix: string, body: any) {
+    httpMock.expectOne(r => r.url.includes(suffix)).flush(body);
+  }
+
+  it('should load every analytics section on init', () => {
+    fixture.detectChanges();
+
+    flushEndingWith('/analytics/languages', [{ language: 'C#', count: 10 }]);
+    flushEndingWith('/analytics/file-types', [{ ext: '.cs', count: 8 }]);
+    flushEndingWith('/analytics/top-terms', [{ term: 'service', count: 5 }]);
+    flushEndingWith('/analytics/complex-files', [{ path: 'a.cs', chunkCount: 3 }]);
+    httpMock.expectOne(r => r.url.includes('/activity-heatmap'))
+      .flush({ stats: { totalCommits: 1 }, dailyData: [] });
+
+    const c = fixture.componentInstance;
+    expect(c.languages.length).toBe(1);
+    expect(c.fileTypes.length).toBe(1);
+    expect(c.topTerms.length).toBe(1);
+    expect(c.complexFiles.length).toBe(1);
+    expect(c.maxLangCount).toBe(10);
+    expect(c.heatmapLoading).toBeFalse();
+  });
+
+  it('should stop the heatmap spinner on error', () => {
+    fixture.detectChanges();
+
+    flushEndingWith('/analytics/languages', []);
+    flushEndingWith('/analytics/file-types', []);
+    flushEndingWith('/analytics/top-terms', []);
+    flushEndingWith('/analytics/complex-files', []);
+    httpMock.expectOne(r => r.url.includes('/activity-heatmap'))
+      .flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
+
+    expect(fixture.componentInstance.heatmapLoading).toBeFalse();
+  });
+});


### PR DESCRIPTION
Part of **epic #246**. Two more previously-untested components specced (suite **104 → 109**).

- **DashboardComponent**: skips fetching when nothing is pinned; loads pinned repos (`forkJoin`) + their bulk sparklines; syncs a repo via the api.
- **RepositoryAnalyticsComponent**: loads all five analytics sections on init (languages, file-types, top-terms, complex-files, activity-heatmap); clears the heatmap spinner on error.

Verified: `npm run lint` ✅ · Karma **109/109** ✅ (headless).

Remaining untested: docs, settings, repository-detail (+ coverage threshold) under #262.

Refs #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)