### PR TITLE
Add specs for settings and docs (story #262)

### DIFF
--- a/client/src/app/components/docs/docs.component.spec.ts
+++ b/client/src/app/components/docs/docs.component.spec.ts
@@ -1,0 +1,53 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { of } from 'rxjs';
+import { DocsComponent } from './docs.component';
+
+describe('DocsComponent', () => {
+  let httpMock: HttpTestingController;
+
+  function setup(params: Record<string, string> = {}): ComponentFixture<DocsComponent> {
+    TestBed.configureTestingModule({
+      imports: [DocsComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ActivatedRoute, useValue: { paramMap: of(convertToParamMap(params)) } },
+      ],
+    });
+    httpMock = TestBed.inject(HttpTestingController);
+    return TestBed.createComponent(DocsComponent);
+  }
+
+  afterEach(() => httpMock.verify());
+
+  it('should load the page named in the route and render its markdown', () => {
+    const fixture = setup({ page: 'search' });
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne('docs/search.md');
+    expect(req.request.responseType).toBe('text');
+    req.flush('# Search\n\nFind things.');
+
+    expect(fixture.componentInstance.renderedHtml).toContain('Search');
+    expect(fixture.componentInstance.loading).toBeFalse();
+  });
+
+  it('should default to getting-started when no page param is present', () => {
+    const fixture = setup();
+    fixture.detectChanges();
+
+    httpMock.expectOne('docs/getting-started.md').flush('# Getting Started');
+    expect(fixture.componentInstance.renderedHtml).toContain('Getting Started');
+  });
+
+  it('should set an error when the page cannot be loaded', () => {
+    const fixture = setup({ page: 'missing' });
+    fixture.detectChanges();
+
+    httpMock.expectOne('docs/missing.md').flush('nope', { status: 404, statusText: 'Not Found' });
+    expect(fixture.componentInstance.error).toContain('missing');
+  });
+});

--- a/client/src/app/components/settings/settings.component.spec.ts
+++ b/client/src/app/components/settings/settings.component.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { SettingsComponent } from './settings.component';
+import { environment } from '../../../environments/environment';
+
+describe('SettingsComponent', () => {
+  let httpMock: HttpTestingController;
+  let fixture: ComponentFixture<SettingsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SettingsComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture = TestBed.createComponent(SettingsComponent);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should load settings, history, and health on init', () => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/settings`).flush({
+      embedding: { model: 'text-embedding-3-small', baseUrl: 'https://api' },
+      llm: { model: 'gpt-4', baseUrl: 'https://llm' },
+    });
+    httpMock.expectOne(`${environment.apiUrl}/settings/history`).flush([{ id: 1 }]);
+    httpMock.expectOne(`${environment.apiUrl}/settings/health`).flush({ ok: true });
+
+    const c = fixture.componentInstance;
+    expect(c.embeddingModel).toBe('text-embedding-3-small');
+    expect(c.llmModel).toBe('gpt-4');
+    expect(c.history.length).toBe(1);
+    expect(c.health).toEqual({ ok: true });
+  });
+
+  it('should POST a connection test and store the result', () => {
+    // No detectChanges → ngOnInit (and its three GETs) does not run.
+    fixture.componentInstance.testConnection('embedding');
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/settings/test-connection`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ type: 'embedding' });
+    req.flush({ success: true });
+
+    expect(fixture.componentInstance.embedTestResult).toEqual({ success: true });
+    expect(fixture.componentInstance.testingEmbed).toBeFalse();
+  });
+});


### PR DESCRIPTION
Part of **epic #246**. Two more previously-untested components specced (suite **109 → 114**).

- **SettingsComponent**: loads settings/history/health on init and maps the embedding & LLM model fields; `testConnection()` POSTs and stores the result.
- **DocsComponent**: loads the markdown page named in the route (defaults to `getting-started`), renders it, and sets an error when the page is missing.

Verified: `npm run lint` ✅ · Karma **114/114** ✅ (headless).

Of the originally untested components, only `repository-detail` (2,449 lines) remains; a coverage threshold is the other open item under #262.

Refs #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)