### PR TITLE
Add embedded SQLite backend (cosine + FTS5 BM25 search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,19 @@ Andy.CodeIndex.sln
 ### Prerequisites
 
 - .NET 8 SDK
-- Docker (for PostgreSQL with pgvector)
+- Docker (optional — only for the PostgreSQL + pgvector backend)
 - Node.js 20+ (for Angular frontend)
 
-### Start the database
+### Database backend
+
+By default the service runs on an **embedded SQLite database** (created at
+`.andy/andy-code-index.db`), so no external database is required — semantic search
+uses in-process cosine similarity over BLOB-stored embeddings and keyword search uses
+SQLite FTS5 (BM25). Override `Sqlite:DataSource` to change the location.
+
+To use **PostgreSQL + pgvector** instead (recommended at larger scale, with HNSW vector
+indexes and native full-text), set `ConnectionStrings:DefaultConnection` and start the
+database:
 
 ```bash
 docker compose up postgres -d

--- a/src/Andy.CodeIndex.Api/Program.cs
+++ b/src/Andy.CodeIndex.Api/Program.cs
@@ -2,6 +2,7 @@ using Andy.Auth.Extensions;
 using Andy.CodeIndex.Application.Interfaces;
 using Andy.CodeIndex.Application.Options;
 using Andy.CodeIndex.Infrastructure.Data;
+using Andy.CodeIndex.Infrastructure.Data.Interceptors;
 using Andy.CodeIndex.Infrastructure.Handlers;
 using Andy.CodeIndex.Infrastructure.Repositories;
 using Andy.CodeIndex.Infrastructure.Services;
@@ -26,8 +27,26 @@ var protectedResourceUrl = $"{serverUrl}/mcp";
 var andyAuthAuthority = builder.Configuration["AndyAuth:Authority"] ?? "";
 
 // --- Database ---
+// Default to an embedded SQLite database so the service runs with no external
+// dependencies; use PostgreSQL + pgvector when a connection string is provided.
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
-if (!string.IsNullOrEmpty(connectionString))
+var useSqlite = string.IsNullOrEmpty(connectionString);
+if (useSqlite)
+{
+    var dataSource = builder.Configuration["Sqlite:DataSource"];
+    if (string.IsNullOrWhiteSpace(dataSource))
+        dataSource = Path.Combine(".andy", "andy-code-index.db");
+
+    var dbDir = Path.GetDirectoryName(Path.GetFullPath(dataSource));
+    if (!string.IsNullOrEmpty(dbDir))
+        Directory.CreateDirectory(dbDir);
+
+    builder.Services.AddDbContext<CodeIndexDbContext>(options =>
+        options
+            .UseSqlite($"Data Source={dataSource}")
+            .AddInterceptors(new EnrichmentFtsInterceptor()));
+}
+else
 {
     builder.Services.AddDbContext<CodeIndexDbContext>(options =>
         options.UseNpgsql(connectionString, o => o.UseVector()));
@@ -452,12 +471,15 @@ app.MapAndyTelemetry();
 
 app.MapFallbackToFile("index.html");
 
-// --- Auto-migrate in development ---
-if (app.Environment.IsDevelopment() && !string.IsNullOrEmpty(connectionString))
+// --- Database schema init ---
+// SQLite (embedded) is created/initialized on every startup; PostgreSQL keeps the
+// development-only auto-migrate.
+using (var scope = app.Services.CreateScope())
 {
-    using var scope = app.Services.CreateScope();
     var db = scope.ServiceProvider.GetRequiredService<CodeIndexDbContext>();
-    if (db.Database.IsNpgsql())
+    if (db.Database.IsSqlite())
+        await SqliteDatabaseInitializer.InitializeAsync(db);
+    else if (db.Database.IsNpgsql() && app.Environment.IsDevelopment())
         await db.Database.MigrateAsync();
 }
 

--- a/src/Andy.CodeIndex.Api/appsettings.json
+++ b/src/Andy.CodeIndex.Api/appsettings.json
@@ -8,7 +8,12 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
+    "_comment": "Set DefaultConnection to a PostgreSQL connection string to use pgvector; leave empty to use the embedded SQLite database below.",
     "DefaultConnection": ""
+  },
+  "Sqlite": {
+    "_comment": "Used only when ConnectionStrings:DefaultConnection is empty. Relative paths are resolved from the working directory (e.g. a project's .andy/ folder).",
+    "DataSource": ".andy/andy-code-index.db"
   },
   "AndyAuth": {
     "Provider": "AndyAuth",

--- a/src/Andy.CodeIndex.Infrastructure/Andy.CodeIndex.Infrastructure.csproj
+++ b/src/Andy.CodeIndex.Infrastructure/Andy.CodeIndex.Infrastructure.csproj
@@ -23,6 +23,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="Pgvector" Version="0.3.2" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.2.1" />

--- a/src/Andy.CodeIndex.Infrastructure/Data/CodeIndexDbContext.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Data/CodeIndexDbContext.cs
@@ -1,4 +1,5 @@
 using Andy.CodeIndex.Domain.Entities;
+using Andy.CodeIndex.Infrastructure.Data.Converters;
 using Microsoft.EntityFrameworkCore;
 
 namespace Andy.CodeIndex.Infrastructure.Data;
@@ -30,6 +31,7 @@ public class CodeIndexDbContext : DbContext
         base.OnModelCreating(modelBuilder);
 
         var isNpgsql = Database.IsNpgsql();
+        var isSqlite = Database.IsSqlite();
 
         if (isNpgsql)
         {
@@ -42,7 +44,7 @@ public class CodeIndexDbContext : DbContext
         ConfigureTag(modelBuilder, isNpgsql);
         ConfigureRepositoryFile(modelBuilder, isNpgsql);
         ConfigureEnrichment(modelBuilder, isNpgsql);
-        ConfigureContentEmbedding(modelBuilder, isNpgsql);
+        ConfigureContentEmbedding(modelBuilder, isNpgsql, isSqlite);
         ConfigureIndexingTask(modelBuilder, isNpgsql);
         ConfigureChunkLineRange(modelBuilder, isNpgsql);
         ConfigureUserSettings(modelBuilder);
@@ -223,7 +225,7 @@ public class CodeIndexDbContext : DbContext
         });
     }
 
-    private static void ConfigureContentEmbedding(ModelBuilder modelBuilder, bool isNpgsql)
+    private static void ConfigureContentEmbedding(ModelBuilder modelBuilder, bool isNpgsql, bool isSqlite)
     {
         modelBuilder.Entity<ContentEmbedding>(builder =>
         {
@@ -244,8 +246,19 @@ public class CodeIndexDbContext : DbContext
                     .HasMethod("hnsw")
                     .HasOperators("vector_cosine_ops");
             }
+            else if (isSqlite)
+            {
+                // SQLite has no native vector type: persist the embedding as a
+                // little-endian float32 BLOB. Cosine similarity is computed in
+                // process in SearchService.SemanticSearchAsync.
+                builder.Property(e => e.EmbeddingVector)
+                    .IsRequired()
+                    .HasColumnType("BLOB")
+                    .HasConversion(new VectorBlobConverter());
+            }
             else
             {
+                // InMemory (unit tests) keeps the previous behaviour.
                 builder.Ignore(e => e.EmbeddingVector);
             }
 

--- a/src/Andy.CodeIndex.Infrastructure/Data/Converters/VectorBlobConverter.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Data/Converters/VectorBlobConverter.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Pgvector;
+
+namespace Andy.CodeIndex.Infrastructure.Data.Converters;
+
+/// <summary>
+/// Stores a pgvector <see cref="Vector"/> as a little-endian float32 BLOB so the
+/// SQLite backend can persist embeddings without the Postgres <c>vector</c> type.
+/// Vector similarity is computed in-process for SQLite (see SearchService); this
+/// converter only handles persistence.
+/// </summary>
+public sealed class VectorBlobConverter : ValueConverter<Vector, byte[]>
+{
+    public VectorBlobConverter()
+        : base(v => ToBytes(v), b => ToVector(b))
+    {
+    }
+
+    public static byte[] ToBytes(Vector vector)
+    {
+        var floats = vector.ToArray();
+        var bytes = new byte[floats.Length * sizeof(float)];
+        Buffer.BlockCopy(floats, 0, bytes, 0, bytes.Length);
+        return bytes;
+    }
+
+    public static float[] ToFloats(byte[] bytes)
+    {
+        var floats = new float[bytes.Length / sizeof(float)];
+        Buffer.BlockCopy(bytes, 0, floats, 0, floats.Length * sizeof(float));
+        return floats;
+    }
+
+    public static Vector ToVector(byte[] bytes) => new(ToFloats(bytes));
+}

--- a/src/Andy.CodeIndex.Infrastructure/Data/Interceptors/EnrichmentFtsInterceptor.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Data/Interceptors/EnrichmentFtsInterceptor.cs
@@ -1,0 +1,114 @@
+using System.Runtime.CompilerServices;
+using Andy.CodeIndex.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Andy.CodeIndex.Infrastructure.Data.Interceptors;
+
+/// <summary>
+/// Keeps the SQLite FTS5 table (<see cref="SqliteDatabaseInitializer.FtsTable"/>)
+/// in sync with <see cref="Enrichment"/> rows so keyword search has BM25-ranked
+/// content. Registered only for the SQLite provider.
+///
+/// Pending changes are captured from the change tracker before save and applied
+/// to the (independent, non-modelled) FTS table after save. State is kept per
+/// <see cref="DbContext"/> via a weak table so a single shared interceptor
+/// instance is safe across contexts.
+/// </summary>
+public sealed class EnrichmentFtsInterceptor : SaveChangesInterceptor
+{
+    private sealed class Pending
+    {
+        public List<(Guid Id, string Content)> Upserts { get; } = new();
+        public List<Guid> Deletes { get; } = new();
+    }
+
+    private readonly ConditionalWeakTable<DbContext, Pending> _pending = new();
+
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData, InterceptionResult<int> result)
+    {
+        Capture(eventData.Context);
+        return base.SavingChanges(eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData, InterceptionResult<int> result, CancellationToken ct = default)
+    {
+        Capture(eventData.Context);
+        return base.SavingChangesAsync(eventData, result, ct);
+    }
+
+    public override int SavedChanges(SaveChangesCompletedEventData eventData, int result)
+    {
+        Apply(eventData.Context);
+        return base.SavedChanges(eventData, result);
+    }
+
+    public override async ValueTask<int> SavedChangesAsync(
+        SaveChangesCompletedEventData eventData, int result, CancellationToken ct = default)
+    {
+        await ApplyAsync(eventData.Context, ct);
+        return await base.SavedChangesAsync(eventData, result, ct);
+    }
+
+    private void Capture(DbContext? context)
+    {
+        if (context is null)
+            return;
+
+        var pending = new Pending();
+        foreach (var entry in context.ChangeTracker.Entries<Enrichment>())
+        {
+            switch (entry.State)
+            {
+                case EntityState.Added:
+                case EntityState.Modified:
+                    pending.Upserts.Add((entry.Entity.Id, entry.Entity.Content));
+                    break;
+                case EntityState.Deleted:
+                    pending.Deletes.Add(entry.Entity.Id);
+                    break;
+            }
+        }
+
+        if (pending.Upserts.Count > 0 || pending.Deletes.Count > 0)
+            _pending.AddOrUpdate(context, pending);
+    }
+
+    private static string Delete => $"DELETE FROM \"{SqliteDatabaseInitializer.FtsTable}\" WHERE EnrichmentId = {{0}};";
+    private static string Insert => $"INSERT INTO \"{SqliteDatabaseInitializer.FtsTable}\" (EnrichmentId, Content) VALUES ({{0}}, {{1}});";
+
+    private void Apply(DbContext? context)
+    {
+        if (context is null || !_pending.TryGetValue(context, out var pending))
+            return;
+        _pending.Remove(context);
+
+        foreach (var id in pending.Deletes)
+            context.Database.ExecuteSqlRaw(Delete, id.ToString());
+
+        foreach (var (id, content) in pending.Upserts)
+        {
+            // FTS5 has no UPSERT; delete-then-insert keeps a single row per id.
+            context.Database.ExecuteSqlRaw(Delete, id.ToString());
+            context.Database.ExecuteSqlRaw(Insert, id.ToString(), content);
+        }
+    }
+
+    private async Task ApplyAsync(DbContext? context, CancellationToken ct)
+    {
+        if (context is null || !_pending.TryGetValue(context, out var pending))
+            return;
+        _pending.Remove(context);
+
+        foreach (var id in pending.Deletes)
+            await context.Database.ExecuteSqlRawAsync(Delete, new object[] { id.ToString() }, ct);
+
+        foreach (var (id, content) in pending.Upserts)
+        {
+            await context.Database.ExecuteSqlRawAsync(Delete, new object[] { id.ToString() }, ct);
+            await context.Database.ExecuteSqlRawAsync(Insert, new object[] { id.ToString(), content }, ct);
+        }
+    }
+}

--- a/src/Andy.CodeIndex.Infrastructure/Data/SqliteDatabaseInitializer.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Data/SqliteDatabaseInitializer.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.CodeIndex.Infrastructure.Data;
+
+/// <summary>
+/// Creates the schema for an embedded SQLite code index plus the FTS5 virtual
+/// table used for BM25 keyword search. Idempotent and safe to call on every
+/// startup of the API or an embedded host (e.g. andy-cli's <c>.andy/</c> store).
+/// </summary>
+public static class SqliteDatabaseInitializer
+{
+    /// <summary>Name of the FTS5 virtual table mirroring enrichment content.</summary>
+    public const string FtsTable = "EnrichmentFts";
+
+    private const string CreateFtsSql =
+        $"CREATE VIRTUAL TABLE IF NOT EXISTS \"{FtsTable}\" USING fts5(EnrichmentId UNINDEXED, Content);";
+
+    public static async Task InitializeAsync(CodeIndexDbContext context, CancellationToken ct = default)
+    {
+        await context.Database.EnsureCreatedAsync(ct);
+        await context.Database.ExecuteSqlRawAsync(CreateFtsSql, ct);
+    }
+
+    public static void Initialize(CodeIndexDbContext context)
+    {
+        context.Database.EnsureCreated();
+        context.Database.ExecuteSqlRaw(CreateFtsSql);
+    }
+}

--- a/src/Andy.CodeIndex.Infrastructure/Handlers/CreateQualityDocsHandler.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Handlers/CreateQualityDocsHandler.cs
@@ -91,11 +91,16 @@ public class CreateQualityDocsHandler : BaseLlmEnrichmentHandler
             catch { }
         }
 
-        var chunks = await Context.Enrichments
+        var chunksQuery = Context.Enrichments
             .Where(e => e.RepositoryId == repo.Id && e.Subtype == EnrichmentSubtype.Chunk)
-            .Where(e => e.FilePath != null && (
-                EF.Functions.ILike(e.FilePath!, "%test%") ||
-                EF.Functions.ILike(e.FilePath!, "%spec%")))
+            .Where(e => e.FilePath != null);
+
+        // ILike is PostgreSQL-only; use a case-insensitive Contains on SQLite/other.
+        chunksQuery = Context.Database.IsNpgsql()
+            ? chunksQuery.Where(e => EF.Functions.ILike(e.FilePath!, "%test%") || EF.Functions.ILike(e.FilePath!, "%spec%"))
+            : chunksQuery.Where(e => e.FilePath!.ToLower().Contains("test") || e.FilePath!.ToLower().Contains("spec"));
+
+        var chunks = await chunksQuery
             .OrderBy(e => e.FilePath)
             .Take(20)
             .ToListAsync(ct);

--- a/src/Andy.CodeIndex.Infrastructure/Services/ChatService.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Services/ChatService.cs
@@ -690,7 +690,13 @@ IMPORTANT: Always use these tools to answer questions. Never say you don't have 
             .Where(f => f.Commit.RepositoryId == repoId.Value);
 
         if (!string.IsNullOrEmpty(pattern))
-            query = query.Where(f => EF.Functions.ILike(f.Path, $"%{pattern}%"));
+        {
+            // ILike is PostgreSQL-only; use a case-insensitive Contains on SQLite/other.
+            var loweredPattern = pattern.ToLower();
+            query = _context.Database.IsNpgsql()
+                ? query.Where(f => EF.Functions.ILike(f.Path, $"%{pattern}%"))
+                : query.Where(f => f.Path.ToLower().Contains(loweredPattern));
+        }
 
         var files = await query
             .OrderBy(f => f.Path)

--- a/src/Andy.CodeIndex.Infrastructure/Services/SearchService.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Services/SearchService.cs
@@ -48,7 +48,12 @@ public class SearchService : ISearchService
         if (queryEmbedding.Length == 0)
             return EmptyResult("semantic", sw);
 
-        // Semantic search requires PostgreSQL with pgvector
+        // SQLite: no pgvector, so rank by cosine similarity computed in process.
+        if (_context.Database.IsSqlite())
+            return await SqliteSemanticSearchAsync(queryEmbedding[0], filter, limit, sw, ct);
+
+        // Otherwise semantic search requires PostgreSQL with pgvector (the
+        // InMemory test provider has no vector support).
         if (!_context.Database.IsNpgsql())
             return EmptyResult("semantic", sw);
 
@@ -132,6 +137,136 @@ public class SearchService : ISearchService
         public double Score { get; set; }
     }
 
+    // SQLite semantic search: load the embeddings for the filtered enrichments and
+    // rank by cosine similarity in process. Suitable for a single-project local
+    // index; for large corpora the pgvector backend should be used instead.
+    private async Task<SearchResultsDto> SqliteSemanticSearchAsync(
+        float[] query, SearchFilter? filter, int limit, Stopwatch sw, CancellationToken ct)
+    {
+        var filteredIds = ApplyEnrichmentFilters(_context.Enrichments.AsQueryable(), filter)
+            .Select(e => e.Id);
+
+        var candidates = await _context.ContentEmbeddings
+            .Include(ce => ce.Enrichment).ThenInclude(e => e.Repository)
+            .Where(ce => filteredIds.Contains(ce.EnrichmentId))
+            .ToListAsync(ct);
+
+        var results = candidates
+            .Select(ce => new SearchResultItem
+            {
+                EnrichmentId = ce.EnrichmentId,
+                Content = ce.Enrichment.Content,
+                Score = Cosine(query, ce.EmbeddingVector.ToArray()),
+                FilePath = ce.Enrichment.FilePath,
+                StartLine = ce.Enrichment.StartLine,
+                EndLine = ce.Enrichment.EndLine,
+                Language = ce.Enrichment.Language,
+                RepositoryId = ce.Enrichment.RepositoryId,
+                RepositoryName = ce.Enrichment.Repository.Name
+            })
+            .OrderByDescending(r => r.Score)
+            .Take(limit)
+            .ToList();
+
+        return new SearchResultsDto
+        {
+            Results = results,
+            TotalCount = results.Count,
+            SearchMode = "semantic",
+            DurationMs = sw.ElapsedMilliseconds
+        };
+    }
+
+    internal static double Cosine(float[] a, float[] b)
+    {
+        if (a.Length == 0 || a.Length != b.Length)
+            return 0;
+
+        double dot = 0, na = 0, nb = 0;
+        for (var i = 0; i < a.Length; i++)
+        {
+            dot += a[i] * b[i];
+            na += a[i] * a[i];
+            nb += b[i] * b[i];
+        }
+
+        if (na == 0 || nb == 0)
+            return 0;
+
+        return dot / (Math.Sqrt(na) * Math.Sqrt(nb));
+    }
+
+    // Row type for the FTS5 BM25 query.
+    internal class FtsHit
+    {
+        public string EnrichmentId { get; set; } = "";
+        public double Score { get; set; }
+    }
+
+    // SQLite keyword search via the FTS5 table with BM25 ranking. Returns hits
+    // intersected with the already-filtered enrichment query.
+    private async Task<List<SearchResultItem>> SqliteKeywordSearchAsync(
+        IQueryable<Enrichment> filtered, string keywords, int limit, CancellationToken ct)
+    {
+        var match = ToFtsMatch(keywords);
+        if (string.IsNullOrWhiteSpace(match))
+            return new List<SearchResultItem>();
+
+        // bm25() returns lower = better. Over-fetch so post-filtering by the
+        // SearchFilter still has enough candidates to fill `limit`.
+        var table = SqliteDatabaseInitializer.FtsTable;
+        var sql =
+            $"SELECT EnrichmentId AS \"EnrichmentId\", bm25(\"{table}\") AS \"Score\" " +
+            $"FROM \"{table}\" WHERE \"{table}\" MATCH {{0}} ORDER BY bm25(\"{table}\") LIMIT {{1}}";
+
+        var hits = await _context.Database
+            .SqlQueryRaw<FtsHit>(sql, match, limit * 4)
+            .ToListAsync(ct);
+
+        if (hits.Count == 0)
+            return new List<SearchResultItem>();
+
+        var scoreById = new Dictionary<Guid, double>();
+        foreach (var hit in hits)
+            if (Guid.TryParse(hit.EnrichmentId, out var id))
+                scoreById[id] = -hit.Score; // higher = better
+
+        var ids = scoreById.Keys.ToList();
+        var rows = await filtered
+            .Where(e => ids.Contains(e.Id))
+            .Select(e => new SearchResultItem
+            {
+                EnrichmentId = e.Id,
+                Content = e.Content,
+                FilePath = e.FilePath,
+                StartLine = e.StartLine,
+                EndLine = e.EndLine,
+                Language = e.Language,
+                RepositoryId = e.RepositoryId,
+                RepositoryName = e.Repository.Name
+            })
+            .ToListAsync(ct);
+
+        foreach (var row in rows)
+            row.Score = scoreById[row.EnrichmentId];
+
+        return rows.OrderByDescending(r => r.Score).Take(limit).ToList();
+    }
+
+    // Builds a safe FTS5 MATCH expression: each token becomes a quoted phrase so
+    // FTS5 operators in user input cannot cause syntax errors. Tokens are implicitly
+    // ANDed by FTS5.
+    private static string ToFtsMatch(string keywords)
+    {
+        var terms = keywords
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
+            .Select(t => new string(t.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray()))
+            .Where(t => t.Length > 0)
+            .Select(t => "\"" + t + "\"");
+
+        return string.Join(" ", terms);
+    }
+
     public async Task<SearchResultsDto> KeywordSearchAsync(string keywords, SearchFilter? filter = null, int limit = 10, CancellationToken ct = default)
     {
         var sw = Stopwatch.StartNew();
@@ -172,6 +307,10 @@ public class SearchService : ISearchService
                     RepositoryName = e.Repository.Name
                 })
                 .ToListAsync(ct);
+        }
+        else if (_context.Database.IsSqlite())
+        {
+            results = await SqliteKeywordSearchAsync(enrichmentQuery, keywords, limit, ct);
         }
         else
         {

--- a/tests/Andy.CodeIndex.Tests.Unit/Data/SqliteSearchTests.cs
+++ b/tests/Andy.CodeIndex.Tests.Unit/Data/SqliteSearchTests.cs
@@ -1,0 +1,189 @@
+using Andy.CodeIndex.Application.Interfaces;
+using Andy.CodeIndex.Domain.Entities;
+using Andy.CodeIndex.Domain.Enums;
+using Andy.CodeIndex.Infrastructure.Data;
+using Andy.CodeIndex.Infrastructure.Data.Interceptors;
+using Andy.CodeIndex.Infrastructure.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Pgvector;
+using Xunit;
+
+namespace Andy.CodeIndex.Tests.Unit.Data;
+
+/// <summary>
+/// End-to-end tests for the SQLite backend: BLOB-stored embeddings ranked by
+/// in-process cosine similarity, and FTS5 BM25 keyword search kept in sync by
+/// <see cref="EnrichmentFtsInterceptor"/>. Uses a real (in-memory) SQLite
+/// connection so the FTS5 virtual table and value converters are exercised.
+/// </summary>
+public class SqliteSearchTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly CodeIndexDbContext _context;
+    private readonly StubEmbeddingProvider _embeddings = new();
+    private readonly SearchService _search;
+    private readonly Guid _repoId = Guid.NewGuid();
+
+    public SqliteSearchTests()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<CodeIndexDbContext>()
+            .UseSqlite(_connection)
+            .AddInterceptors(new EnrichmentFtsInterceptor())
+            .Options;
+
+        _context = new CodeIndexDbContext(options);
+        SqliteDatabaseInitializer.Initialize(_context);
+
+        _search = new SearchService(
+            _context, _embeddings, new RankFusionService(), NullLogger<SearchService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task SemanticSearch_RanksClosestEmbeddingFirst()
+    {
+        SeedRepo(_repoId, "repo1");
+        var login = SeedEnrichment(_repoId, "user authentication and login flow", "csharp", new[] { 1f, 0f, 0f });
+        SeedEnrichment(_repoId, "database migration scripts", "csharp", new[] { 0f, 1f, 0f });
+        SeedEnrichment(_repoId, "frontend rendering pipeline", "typescript", new[] { 0f, 0f, 1f });
+        await _context.SaveChangesAsync();
+
+        _embeddings.Query = new[] { 0.9f, 0.1f, 0f }; // closest to the login embedding
+
+        var results = await _search.SemanticSearchAsync("anything", limit: 3);
+
+        Assert.NotEmpty(results.Results);
+        Assert.Equal(login, results.Results[0].EnrichmentId);
+        Assert.True(results.Results[0].Score > results.Results[^1].Score);
+    }
+
+    [Fact]
+    public async Task SemanticSearch_RespectsLanguageFilter()
+    {
+        SeedRepo(_repoId, "repo1");
+        SeedEnrichment(_repoId, "csharp content", "csharp", new[] { 1f, 0f, 0f });
+        var ts = SeedEnrichment(_repoId, "typescript content", "typescript", new[] { 1f, 0f, 0f });
+        await _context.SaveChangesAsync();
+
+        _embeddings.Query = new[] { 1f, 0f, 0f };
+
+        var results = await _search.SemanticSearchAsync(
+            "anything", new SearchFilter { Languages = new() { "typescript" } }, limit: 10);
+
+        Assert.All(results.Results, r => Assert.Equal("typescript", r.Language));
+        Assert.Contains(results.Results, r => r.EnrichmentId == ts);
+    }
+
+    [Fact]
+    public async Task KeywordSearch_ReturnsBm25RankedResults()
+    {
+        SeedRepo(_repoId, "repo1");
+        var dense = SeedEnrichment(_repoId, "database database database connection pool", "csharp");
+        var sparse = SeedEnrichment(_repoId, "database migration scripts for the service", "csharp");
+        SeedEnrichment(_repoId, "unrelated rendering pipeline", "csharp");
+        await _context.SaveChangesAsync();
+
+        var results = await _search.KeywordSearchAsync("database", limit: 10);
+
+        var ids = results.Results.Select(r => r.EnrichmentId).ToList();
+        Assert.Contains(dense, ids);
+        Assert.Contains(sparse, ids);
+        // More frequent term occurrences in a shorter document rank higher under BM25.
+        Assert.True(ids.IndexOf(dense) < ids.IndexOf(sparse));
+    }
+
+    [Fact]
+    public async Task KeywordSearch_OnlyMatchesDocumentsContainingTerm()
+    {
+        SeedRepo(_repoId, "repo1");
+        var match = SeedEnrichment(_repoId, "authentication middleware setup", "csharp");
+        SeedEnrichment(_repoId, "database migration scripts", "csharp");
+        await _context.SaveChangesAsync();
+
+        var results = await _search.KeywordSearchAsync("authentication", limit: 10);
+
+        Assert.Single(results.Results);
+        Assert.Equal(match, results.Results[0].EnrichmentId);
+    }
+
+    [Fact]
+    public async Task HybridSearch_ReturnsMatchingEnrichment()
+    {
+        SeedRepo(_repoId, "repo1");
+        var target = SeedEnrichment(_repoId, "authentication and login flow", "csharp", new[] { 1f, 0f, 0f });
+        SeedEnrichment(_repoId, "frontend rendering pipeline", "typescript", new[] { 0f, 0f, 1f });
+        await _context.SaveChangesAsync();
+
+        _embeddings.Query = new[] { 1f, 0f, 0f };
+
+        var results = await _search.HybridSearchAsync("authentication", limit: 10);
+
+        Assert.NotEmpty(results.Results);
+        Assert.Contains(results.Results, r => r.EnrichmentId == target);
+    }
+
+    private void SeedRepo(Guid id, string name)
+    {
+        _context.Repositories.Add(new Repository
+        {
+            Id = id,
+            Name = name,
+            Url = $"https://example.test/{name}",
+            Status = "indexed",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+    }
+
+    private Guid SeedEnrichment(Guid repoId, string content, string language, float[]? embedding = null)
+    {
+        var id = Guid.NewGuid();
+        var enrichment = new Enrichment
+        {
+            Id = id,
+            RepositoryId = repoId,
+            Type = EnrichmentType.Development,
+            Subtype = EnrichmentSubtype.Chunk,
+            Content = content,
+            Language = language,
+            FilePath = $"src/{id:N}.cs",
+            CreatedAt = DateTime.UtcNow
+        };
+        _context.Enrichments.Add(enrichment);
+
+        if (embedding is not null)
+        {
+            _context.ContentEmbeddings.Add(new ContentEmbedding
+            {
+                Id = Guid.NewGuid(),
+                EnrichmentId = id,
+                EmbeddingVector = new Vector(embedding),
+                IndexType = IndexType.Code,
+                CreatedAt = DateTime.UtcNow
+            });
+        }
+
+        return id;
+    }
+
+    private sealed class StubEmbeddingProvider : IEmbeddingProvider
+    {
+        public float[] Query { get; set; } = { 1f, 0f, 0f };
+        public int Dimensions => Query.Length;
+        public string ModelName => "stub";
+        public bool IsAvailable => true;
+
+        public Task<float[][]> GenerateEmbeddingsAsync(string[] texts, CancellationToken ct = default)
+            => Task.FromResult(texts.Select(_ => Query).ToArray());
+    }
+}


### PR DESCRIPTION
## Summary

Makes **SQLite the default database** so andy-code-index runs with no external dependencies — enabling `andy` (andy-cli) to carry its own small, local index in a temporary `.andy/` directory. **PostgreSQL + pgvector remains fully supported** behind the existing `IsNpgsql()` conditionals (dual-provider).

### How search works on SQLite (no pgvector)
- **Semantic**: embeddings persist as a float32 **BLOB** (`VectorBlobConverter`); ranking is **in-process cosine similarity** over the filtered candidate set. Fine at single-project local-index scale.
- **Keyword**: a SQLite **FTS5** virtual table (`EnrichmentFts`) kept in sync by `EnrichmentFtsInterceptor`, queried with real **BM25** ranking.
- **Schema**: `EnsureCreated` (no migrations) — fits an ephemeral/regenerable `.andy/` DB. Postgres keeps `Migrate()`.

### Changes
- `Program.cs`: provider selection — default `UseSqlite` at `.andy/andy-code-index.db` (override via `Sqlite:DataSource`); `UseNpgsql(...).UseVector()` when `ConnectionStrings:DefaultConnection` is set. SQLite schema initialized on every startup.
- `SqliteDatabaseInitializer`: `EnsureCreated` + idempotent FTS5 DDL.
- `CodeIndexDbContext`: SQLite branch maps `EmbeddingVector` to a BLOB via converter (InMemory unit-test path unchanged).
- `SearchService`: SQLite semantic (cosine) + keyword (FTS5 BM25) branches; pgvector/tsvector paths untouched.
- Made two `EF.Functions.ILike` usages provider-conditional (SQLite-safe `Contains`).
- Added `Microsoft.EntityFrameworkCore.Sqlite`.

### Tests
- New `SqliteSearchTests` (real in-memory SQLite connection) covers semantic ranking, BM25 keyword ranking, term matching, language filter, and hybrid search — all green.
- Full unit suite: 826 passed, same 4 pre-existing unrelated failures, **no regressions**. Postgres `HybridSearchPgvectorTests` (Testcontainers) and the InMemory branches are untouched.

### Notes
- No embedding-provider key → semantic search returns empty (unchanged); FTS5 keyword search still works offline.
- Wiring andy-cli to drive the full indexing pipeline against its `.andy/` DB is a follow-up; this PR delivers the SQLite-backed store + working search it can adopt.