### PR TITLE
Fix repository list stats (commitCount/fileCount reported as 0)

### DIFF
--- a/src/Andy.CodeIndex.Infrastructure/Services/RepositoryService.cs
+++ b/src/Andy.CodeIndex.Infrastructure/Services/RepositoryService.cs
@@ -102,13 +102,34 @@ public class RepositoryService : IRepositoryService
             Name = t.Name,
             CommitSha = t.CommitSha
         }).ToList();
+        dto.Stats = await BuildStatsAsync(repo, ct);
+
+        return dto;
+    }
+
+    /// <summary>
+    /// Computes the full statistics for a repository. Shared by <see cref="GetDetailsByIdAsync"/>
+    /// and <see cref="ListAsync"/> so both endpoints report the same numbers.
+    /// </summary>
+    private async Task<RepositoryStatsDto> BuildStatsAsync(Repository repo, CancellationToken ct)
+    {
+        var id = repo.Id;
+
+        var enrichmentCount = await _enrichmentRepo.CountAsync(e => e.RepositoryId == id, ct);
         var embeddingCount = await _context.ContentEmbeddings
             .CountAsync(ce => _context.Enrichments
                 .Where(e => e.RepositoryId == id)
                 .Select(e => e.Id)
                 .Contains(ce.EnrichmentId), ct);
-
-        var enrichmentCount = await _enrichmentRepo.CountAsync(e => e.RepositoryId == id, ct);
+        var storageSizeBytes = await _context.Enrichments
+            .Where(e => e.RepositoryId == id)
+            .SumAsync(e => (long)e.Content.Length, ct);
+        var commitCount = await _commitRepo.CountAsync(c => c.RepositoryId == id, ct);
+        // RepositoryFiles link to a Commit, which links to the repository.
+        var fileCount = await _context.RepositoryFiles
+            .CountAsync(f => f.Commit.RepositoryId == id, ct);
+        var pendingTaskCount = await _taskRepo.CountAsync(
+            t => t.RepositoryId == id && t.Status == IndexingTaskStatus.Pending, ct);
         var hasInsights = await _context.Enrichments
             .AnyAsync(e => e.RepositoryId == id && e.Type == EnrichmentType.Insights, ct);
 
@@ -124,25 +145,19 @@ public class RepositoryService : IRepositoryService
         else if (enrichmentCount > 0 && !hasInsights)
         { needsAttention = true; attentionReason = "No insights generated"; }
 
-        var storageSizeBytes = await _context.Enrichments
-            .Where(e => e.RepositoryId == id)
-            .SumAsync(e => (long)e.Content.Length, ct);
-
-        dto.Stats = new RepositoryStatsDto
+        return new RepositoryStatsDto
         {
-            CommitCount = await _commitRepo.CountAsync(c => c.RepositoryId == id, ct),
+            CommitCount = commitCount,
+            FileCount = fileCount,
             EnrichmentCount = enrichmentCount,
             StorageSizeBytes = storageSizeBytes,
             EmbeddingCount = embeddingCount,
             HasEmbeddings = embeddingCount > 0,
-            PendingTaskCount = await _taskRepo.CountAsync(
-                t => t.RepositoryId == id && t.Status == IndexingTaskStatus.Pending, ct),
+            PendingTaskCount = pendingTaskCount,
             NeedsAttention = needsAttention,
             AttentionReason = attentionReason,
             HasInsights = hasInsights
         };
-
-        return dto;
     }
 
     public async Task<List<RepositoryDto>> ListAsync(GitProvider? provider = null, string? status = null, CancellationToken ct = default)
@@ -160,22 +175,7 @@ public class RepositoryService : IRepositoryService
         foreach (var repo in repos)
         {
             var dto = MapToDto(repo);
-            var enrichmentCount = await _enrichmentRepo.CountAsync(e => e.RepositoryId == repo.Id, ct);
-            var embeddingCount = await _context.ContentEmbeddings
-                .CountAsync(ce => _context.Enrichments
-                    .Where(e => e.RepositoryId == repo.Id)
-                    .Select(e => e.Id)
-                    .Contains(ce.EnrichmentId), ct);
-            var storageSizeBytes = await _context.Enrichments
-                .Where(e => e.RepositoryId == repo.Id)
-                .SumAsync(e => (long)e.Content.Length, ct);
-            dto.Stats = new RepositoryStatsDto
-            {
-                EnrichmentCount = enrichmentCount,
-                StorageSizeBytes = storageSizeBytes,
-                EmbeddingCount = embeddingCount,
-                HasEmbeddings = embeddingCount > 0
-            };
+            dto.Stats = await BuildStatsAsync(repo, ct);
             dtos.Add(dto);
         }
         return dtos;

--- a/tests/Andy.CodeIndex.Tests.Unit/Services/RepositoryStatsTests.cs
+++ b/tests/Andy.CodeIndex.Tests.Unit/Services/RepositoryStatsTests.cs
@@ -1,0 +1,126 @@
+using Andy.CodeIndex.Domain.Entities;
+using Andy.CodeIndex.Domain.Enums;
+using Andy.CodeIndex.Infrastructure.Data;
+using Andy.CodeIndex.Infrastructure.Repositories;
+using Andy.CodeIndex.Infrastructure.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.CodeIndex.Tests.Unit.Services;
+
+/// <summary>
+/// Verifies repository stats are computed correctly and consistently across the
+/// single-repo (<see cref="RepositoryService.GetDetailsByIdAsync"/>) and list
+/// (<see cref="RepositoryService.ListAsync"/>) endpoints — including CommitCount
+/// and FileCount, which the list endpoint previously left at zero.
+/// </summary>
+public class RepositoryStatsTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly CodeIndexDbContext _context;
+    private readonly RepositoryService _service;
+    private readonly Guid _repoId = Guid.NewGuid();
+
+    public RepositoryStatsTests()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<CodeIndexDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _context = new CodeIndexDbContext(options);
+        SqliteDatabaseInitializer.Initialize(_context);
+
+        _service = new RepositoryService(
+            new CodeRepositoryRepository(_context),
+            new CommitRepository(_context),
+            new EnrichmentRepository(_context),
+            new IndexingTaskRepository(_context),
+            _context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task Stats_AreComputed_AndConsistentAcrossListAndDetail()
+    {
+        await SeedAsync(commits: 3, filesPerCommit: 2, enrichments: 5);
+
+        var detail = await _service.GetDetailsByIdAsync(_repoId);
+        var list = await _service.ListAsync();
+        var listed = Assert.Single(list);
+
+        Assert.NotNull(detail!.Stats);
+        Assert.NotNull(listed.Stats);
+
+        // The actual data is reported, not zero.
+        Assert.Equal(3, detail.Stats!.CommitCount);
+        Assert.Equal(6, detail.Stats.FileCount); // 3 commits * 2 files
+        Assert.Equal(5, detail.Stats.EnrichmentCount);
+
+        // Both endpoints agree.
+        Assert.Equal(detail.Stats.CommitCount, listed.Stats!.CommitCount);
+        Assert.Equal(detail.Stats.FileCount, listed.Stats.FileCount);
+        Assert.Equal(detail.Stats.EnrichmentCount, listed.Stats.EnrichmentCount);
+    }
+
+    private async Task SeedAsync(int commits, int filesPerCommit, int enrichments)
+    {
+        _context.Repositories.Add(new Repository
+        {
+            Id = _repoId,
+            Name = "demo",
+            Url = "https://example.test/demo",
+            Status = "indexed",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+
+        for (var i = 0; i < commits; i++)
+        {
+            var commitId = Guid.NewGuid();
+            _context.Commits.Add(new Commit
+            {
+                Id = commitId,
+                RepositoryId = _repoId,
+                Sha = $"sha{i:D4}",
+                Message = $"commit {i}",
+                CommittedAt = DateTime.UtcNow,
+                CreatedAt = DateTime.UtcNow
+            });
+
+            for (var f = 0; f < filesPerCommit; f++)
+            {
+                _context.Set<RepositoryFile>().Add(new RepositoryFile
+                {
+                    Id = Guid.NewGuid(),
+                    CommitId = commitId,
+                    Path = $"src/file{i}_{f}.cs",
+                    CreatedAt = DateTime.UtcNow
+                });
+            }
+        }
+
+        for (var i = 0; i < enrichments; i++)
+        {
+            _context.Enrichments.Add(new Enrichment
+            {
+                Id = Guid.NewGuid(),
+                RepositoryId = _repoId,
+                Type = EnrichmentType.Development,
+                Subtype = EnrichmentSubtype.Chunk,
+                Content = $"chunk {i}",
+                CreatedAt = DateTime.UtcNow
+            });
+        }
+
+        await _context.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
## Summary

The repositories **list** endpoint reported `commitCount`, `fileCount`, and `pendingTaskCount` as `0` even when the data existed, because `RepositoryService.ListAsync` only populated a subset of stats (`EnrichmentCount`/`StorageSizeBytes`/`EmbeddingCount`). Separately, **`FileCount` was never computed** in either the list or the detail path.

Found while verifying the SQLite backend: an indexed repo showed `commitCount: 0` / `fileCount: 0` in the list, while the detail endpoint correctly showed `commitCount: 226`. This is pre-existing behavior, unrelated to the SQLite migration.

## Fix

- Extract a single `BuildStatsAsync(repo, ct)` used by **both** `GetDetailsByIdAsync` and `ListAsync`, so the two endpoints always report the same numbers (the root cause was duplicated, divergent stats logic).
- Compute `FileCount` by counting `RepositoryFiles` through their `Commit` (`f.Commit.RepositoryId == id`).

## Verification

- New `RepositoryStatsTests` asserts `CommitCount`/`FileCount`/`EnrichmentCount` are correct **and identical** across the list and detail endpoints (real SQLite).
- Verified against a live-indexed repo (andy-code-index itself): the **list** endpoint now returns `commitCount 226 | fileCount 381 | enrichmentCount 2522`, matching the detail endpoint.
- Full unit suite: 827 passed, same 4 pre-existing unrelated failures, no regressions.