### PR TITLE
Update EF Core 8 and SQLite dependencies

### DIFF
--- a/src/Andy.CodeIndex.Api/Andy.CodeIndex.Api.csproj
+++ b/src/Andy.CodeIndex.Api/Andy.CodeIndex.Api.csproj
@@ -20,9 +20,9 @@
          Andy.Telemetry (which also adds OTLP, Prometheus, Http and
          Runtime instrumentation). -->
     <PackageReference Include="Andy.Telemetry" Version="0.2.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.29" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.29" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.29">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Andy.CodeIndex.Infrastructure/Andy.CodeIndex.Infrastructure.csproj
+++ b/src/Andy.CodeIndex.Infrastructure/Andy.CodeIndex.Infrastructure.csproj
@@ -11,19 +11,20 @@
 
   <ItemGroup>
     <PackageReference Include="Acornima" Version="1.6.2" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.11" />
-    <!-- Pinned to 4.5.0 to match the version EF Core Design 8.0.11 transitively
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.29" />
+    <!-- Pinned to 4.5.0 to match the version EF Core Design 8.0.29 transitively
          requires (Microsoft.CodeAnalysis.CSharp.Workspaces 4.5.0 → Common 4.5.0). -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.29" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.29">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.29" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="Pgvector" Version="0.3.2" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.2.1" />

--- a/tests/Andy.CodeIndex.Tests.Integration/Andy.CodeIndex.Tests.Integration.csproj
+++ b/tests/Andy.CodeIndex.Tests.Integration/Andy.CodeIndex.Tests.Integration.csproj
@@ -11,8 +11,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.29" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.29" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.12.0" />

--- a/tests/Andy.CodeIndex.Tests.Unit/Andy.CodeIndex.Tests.Unit.csproj
+++ b/tests/Andy.CodeIndex.Tests.Unit/Andy.CodeIndex.Tests.Unit.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.29" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />


### PR DESCRIPTION
Updates the .NET 8 EF Core and ASP.NET package family from 8.0.11 to the current 8.0.29 servicing release. It also pins SQLitePCLRaw.bundle_e_sqlite3 2.1.12 so the published Infrastructure package no longer resolves the vulnerable 2.1.6 native SQLite library (GHSA-2m69-gcr7-jv3q).\n\nValidation:\n- dotnet test Andy.CodeIndex.sln --no-restore (938 passed)\n- dotnet list src/Andy.CodeIndex.Infrastructure/Andy.CodeIndex.Infrastructure.csproj package --vulnerable --include-transitive (none)\n- git diff --check\n- dotnet format --verify-no-changes reports the repository's existing broad whitespace backlog; this package-only change does not modify C# source